### PR TITLE
Fix opcode collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "asm-lsp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "flexi_logger",

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,7 +157,8 @@ impl std::fmt::Display for InstructionForm {
 }
 
 // helper structs, types and functions ------------------------------------------------------------
-pub type NameToInstructionMap<'instruction> = HashMap<&'instruction str, &'instruction Instruction>;
+pub type NameToInstructionMap<'instruction> =
+    HashMap<(Arch, &'instruction str), &'instruction Instruction>;
 
 #[derive(Debug, Clone, EnumString, AsRefStr)]
 pub enum XMMMode {
@@ -171,7 +172,7 @@ pub enum MMXMode {
     MMX,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, EnumString, AsRefStr)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, EnumString, AsRefStr)]
 pub enum Arch {
     X86,
     X86_64,

--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -249,12 +249,13 @@ pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instructi
 }
 
 pub fn populate_name_to_instruction_map<'instruction>(
+    arch: Arch,
     instructions: &'instruction Vec<Instruction>,
     names_to_instructions: &mut NameToInstructionMap<'instruction>,
 ) {
     for instruction in instructions {
         for name in &instruction.get_associated_names() {
-            names_to_instructions.insert(name, instruction);
+            names_to_instructions.insert((arch, name), instruction);
         }
     }
 }


### PR DESCRIPTION
Change the `names_to_instructions` HashMap to accept keys of `(Arch, &str)` so x86_64 instructions no longer overwrite x86 instructions of the same name at load time. When both x86 and x86_64 have an instruction of the same name, both are displayed when using hover functionality,