### PR TITLE
First pass on adding select target feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ tags
 # End of https://www.toptal.com/developers/gitignore/api/rust,vim,python
 
 rusty-tags.vi
+
+/.asm-lsp.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "toml",
 ]
 
 [[package]]
@@ -186,6 +187,12 @@ checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -332,7 +339,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -344,6 +351,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -468,7 +481,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -921,6 +944,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1120,40 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1348,6 +1414,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 serde_json = "1.0.94"
 serde = "1.0.158"
+toml = "0.8.1"
 
 # [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Add a section like the following in your `settings.json` file:
 }
 ```
 
+Add a `.asm-lsp.toml` file like the following to your project's root directory 
+to selectively target specific assemblers and/or instruction sets:
+
+```toml
+version = "0.1"
+
+[assemblers]
+gas = true
+go = false
+
+[instruction_sets]
+x86 = false
+x86_64 = true
+```
+
 ## Demo
 
 ### Hovering / Documentation support

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Add a section like the following in your `settings.json` file:
 }
 ```
 
-Add a `.asm-lsp.toml` file like the following to your project's root directory 
+### [OPTIONAL] Configure via `.asm-lsp.toml`
+
+Add a `.asm-lsp.toml` file like the following to your project's root directory
 to selectively target specific assemblers and/or instruction sets:
 
 ```toml

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -48,7 +48,7 @@ pub fn main() -> anyhow::Result<()> {
     );
 
     // LSP server initialisation ------------------------------------------------------------------
-    info!("Starting lsp server...");
+    info!("Starting LSP server...");
 
     // Create the transport
     let (connection, io_threads) = Connection::stdio();
@@ -59,13 +59,13 @@ pub fn main() -> anyhow::Result<()> {
         hover_provider,
         ..ServerCapabilities::default()
     };
-    let server_capabilities = serde_json::to_value(&capabilities).unwrap();
+    let server_capabilities = serde_json::to_value(capabilities).unwrap();
     let initialization_params = connection.initialize(server_capabilities)?;
     main_loop(&connection, initialization_params, &names_to_instructions)?;
     io_threads.join()?;
 
     // Shut down gracefully.
-    info!("Shutting down lsp server");
+    info!("Shutting down LSP server");
     Ok(())
 }
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -90,7 +90,7 @@ pub fn get_target_config(params: &InitializeParams) -> TargetConfig {
 
     // if we have a properly configured root path, check for the config file
     if let Some(mut path) = root_path {
-        path.push(".asm-lsp");
+        path.push(".asm-lsp.toml");
         if let Ok(config) = std::fs::read_to_string(path.clone()) {
             let path_s = path.display();
             match toml::from_str::<TargetConfig>(&config) {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -109,15 +109,15 @@ pub fn get_target_config(params: &InitializeParams) -> TargetConfig {
     TargetConfig::default()
 }
 
-pub fn filter_targets(instr: &&Instruction, config: &TargetConfig) -> Instruction {
-    let mut instr = (*instr).clone();
+pub fn filter_targets(instr: &Instruction, config: &TargetConfig) -> Instruction {
+    let mut instr = instr.clone();
 
     let forms = instr
         .forms
         .iter()
         .filter(|form| {
-            (form.go_name.is_some() && config.assemblers.go)
-                || (form.gas_name.is_some() && config.assemblers.gas)
+            (form.gas_name.is_some() && config.assemblers.gas)
+                || (form.go_name.is_some() && config.assemblers.go)
         })
         .map(|form| {
             let mut filtered = form.clone();

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,7 +1,9 @@
 use crate::types::Column;
-use lsp_types::TextDocumentPositionParams;
+use crate::{TargetConfig, Instruction};
+use lsp_types::{TextDocumentPositionParams, InitializeParams, Url};
 use std::fs::File;
 use std::io::BufRead;
+use log::info;
 /// Find the start and end indices of a word inside the given line
 /// Borrowed from RLS
 pub fn find_word_at_pos(line: &str, col: Column) -> (Column, Column) {
@@ -47,4 +49,83 @@ pub fn get_word_from_file_params(
         }
         Err(_) => Err(anyhow::anyhow!("filepath get error")),
     }
+}
+
+pub fn get_target_config(params: &InitializeParams) -> TargetConfig {
+    // first check workspace folders
+    let root_path = if let Some(folders) = &params.workspace_folders {
+        // if there's multiple, just visit in order until we find a valid folder
+        let mut path = None;
+        for folder in folders.iter() {
+            if let Ok(parsed) = Url::parse(folder.uri.as_str()) {
+                if let Ok(parsed_path) = parsed.to_file_path() {
+                    path = Some(parsed_path);
+                    break;
+                }
+            }
+        }
+        path
+    } else {
+        None
+    };
+    
+    // if workspace folders weren't set or came up empty, we check the root_uri
+    let root_path = if root_path.is_none() {
+        if let Some(root_uri) = &params.root_uri {
+            if let Ok(path) = root_uri.to_file_path() {
+                Some(path)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        root_path
+    };
+
+    // if we have a properly configured root path, check for the config file
+    if let Some(mut path) = root_path {
+        path.push(".asm-lsp");
+        if let Ok(config) = std::fs::read_to_string(path) {
+            match toml::from_str::<TargetConfig>(&config) {
+                Ok(config) => return config,
+                Err(e) => {
+                    info!(
+                        "Failed to parse config file: {e}\n"
+                    );
+                } // if there's an error we fall through to the default
+            }
+        }
+    }
+
+    // default is to turn everything on
+    return TargetConfig::default();
+}
+
+pub fn filter_targets(instr: &&Instruction, config: &TargetConfig) -> Instruction {
+    let mut instr = (*instr).clone();
+
+    let forms = instr
+        .forms
+        .iter()
+        .filter(|form| {
+            (form.go_name.is_some() && config.assemblers.go)
+                || (form.gas_name.is_some() && config.assemblers.gas)
+        })
+    .map(|form| {
+        let mut filtered = form.clone();
+        // handle cases where gas and go both have names on the same form
+        if !(config.assemblers.gas) {
+            filtered.gas_name = None;
+        }
+        if !(config.assemblers.go) {
+            filtered.go_name = None;
+        }
+        filtered
+    })
+    .collect();
+
+    instr.forms = forms;
+    return instr;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use strum_macros::{AsRefStr, EnumString};
+use serde::{Serialize, Deserialize};
 
 // Instruction ------------------------------------------------------------------------------------
 #[derive(Debug, Clone)]
@@ -176,6 +177,53 @@ pub enum MMXMode {
 pub enum Arch {
     X86,
     X86_64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Assemblers {
+    pub gas: bool,
+    pub go: bool,
+}
+
+impl Default for Assemblers {
+    fn default() -> Self {
+        Assemblers {
+            gas: true,
+            go: true
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstructionSets {
+    pub x86: bool,
+    pub x86_64: bool,
+}
+
+impl Default for InstructionSets {
+    fn default() -> Self {
+        InstructionSets {
+            x86: true,
+            x86_64: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TargetConfig {
+    pub version: String,
+    pub assemblers: Assemblers,
+    pub instruction_sets: InstructionSets,
+}
+
+impl Default for TargetConfig {
+    fn default() -> Self {
+        TargetConfig {
+            version: String::from("0.1"),
+            assemblers: Assemblers::default(),
+            instruction_sets: InstructionSets::default(),
+        }
+    }
 }
 
 // Instruction Set Architecture -------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use strum_macros::{AsRefStr, EnumString};
-use serde::{Serialize, Deserialize};
 
 // Instruction ------------------------------------------------------------------------------------
 #[derive(Debug, Clone)]
@@ -189,7 +189,7 @@ impl Default for Assemblers {
     fn default() -> Self {
         Assemblers {
             gas: true,
-            go: true
+            go: true,
         }
     }
 }


### PR DESCRIPTION
Add select target feature, allowing users to specify in a .asm-lsp config file which assembler(s) and architecture(s) they want the LSP to target.

Feature likely needs more investigation regarding workspaceFolders.