### PR TITLE
CI: add workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,10 +8,15 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
 jobs:
-  security_audit:
+  audit:
+    name: Security Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        name: Checkout
+
       - uses: taiki-e/install-action@cargo-deny
+        name: Install cargo-deny
+
       - name: Scan for vulnerabilities
         run: cargo deny check advisories

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,17 @@
+name: Security audit
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Scan for vulnerabilities
+        run: cargo deny check advisories

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ env:
 
 jobs:
   build:
+    name: Build Cargo Workspace
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
@@ -25,12 +25,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Cache dependencies
 
-      # FIXME: those may be installed by default on Ubuntu, I don't remember
-      # needs to be tested on a machine running ubuntu
+      # FIXME: those may be installed by default on Ubuntu, but I know they do not come installed on Nix
+      # needs to be tested on a machine running ubuntu and removed if this section is redundant
       - name: Install build deps
         run: |
           sudo apt-get update
           sudo apt-get install openssl pkg-config
 
-      - name: Build
-        run: cargo build --verbose --workspace
+      - uses: actions-rs/cargo@v1
+        name: Build crate
+        with:
+          command: build
+          args: --verbose --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Cargo Workspace
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      # FIXME: those may be installed by default on Ubuntu, I don't remember
+      # needs to be tested on a machine running ubuntu
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install openssl pkg-config
+
+      - name: Build
+        run: cargo build --verbose --workspace

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Check Documentation
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rustdoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+
+      - uses: actions-rs/toolchain@v1
+        name: Install rust toolchain
+        with:
+          toolchain: nightly
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+        name: Smart caching for Cargo
+
+      - uses: actions-rs/cargo@v1
+        name: Check Documentation with Rustdoc
+        with:
+          command: doc
+          args: --verbose --no-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,16 @@ env:
 
 jobs:
   rustdoc:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
 
       - uses: actions-rs/toolchain@v1
         name: Install rust toolchain
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    name: Publish
+    name: Publish Crate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Crate
+
+on:
+  workflow_dispatch:
+  push:
+    # Pattern matched against refs/tags
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ignore-unpublished-changes: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches: ["master"]
     paths:
-      - ".github/workflows/unit-tests.yml"
+      - ".github/workflows/tests.yml"
       - "src/**"
       - "Cargo.*"
       - build.rs
@@ -24,7 +24,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  unit-tests:
+  tests:
+    name: Run Unit Tests
     runs-on: ${{ matrix.os }}
 
     continue-on-error: ${{ matrix.rust == 'nightly' }}
@@ -40,13 +41,6 @@ jobs:
 
       - run: rustup toolchain install ${{ matrix.rust }} --profile minimal
       - uses: Swatinem/rust-cache@v2
-
-      - name: Install cargo-hack
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: cargo install cargo-hack
 
       - name: Run rustfmt checks
         run: cargo fmt --check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+    paths:
+      - "src/**"
+      - "Cargo.*"
+      - build.rs
+  pull_request:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/unit-tests.yml"
+      - "src/**"
+      - "Cargo.*"
+      - build.rs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit-tests:
+    runs-on: ${{ matrix.os }}
+
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [1.70.0, stable, beta, nightly]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - run: rustup toolchain install ${{ matrix.rust }} --profile minimal
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-hack
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: cargo install cargo-hack
+
+      - name: Run rustfmt checks
+        run: cargo fmt --check
+
+      - name: Run clippy lints
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
adds some basic workflows that handle 
- checking documentation
- auditing dependencies
- testing formatting
- build testing
- unit testing (just the groundwork)
- publishing crates

I've tested the workflows best I could using act, the publish workflow could not be tested as it needs tagging.
Closes #11 