### PR TITLE
Add caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ version = "0.3.3"
 dependencies = [
  "anyhow",
  "flexi_logger",
+ "home",
  "log",
  "lsp-server",
  "lsp-types",
@@ -369,6 +370,15 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "asm-lsp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "flexi_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,6 @@ strum_macros = "0.24.3"
 serde_json = "1.0.94"
 serde = "1.0.158"
 toml = "0.8.1"
+home = "0.5.5"
 
 # [dev-dependencies]

--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -227,8 +227,7 @@ pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instructi
     // Do we want to change behavior on error and just not include the web info?
     //  e.g change body over to an option and only mutate the map if it's Some(_)
     let cache_refresh = args() // replace with an actual way to check CLI args
-        .into_iter()
-        .fold(false, |accum, arg| accum || arg.contains("refresh"));
+        .any(|arg| arg.contains("refresh"));
     let x86_online_docs = String::from("https://www.felixcloutier.com/x86/");
     let mut x86_cache_path = match get_cache_dir() {
         Ok(cache_path) => cache_path,
@@ -240,10 +239,7 @@ pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instructi
 
     // At this point we have a valid directory, now append the file name
     x86_cache_path.push("x86_docs.cache");
-    let cache_exists = match x86_cache_path.try_exists() {
-        Ok(true) => true,
-        _ => false,
-    };
+    let cache_exists = matches!(x86_cache_path.try_exists(), Ok(true));
 
     let body = if cache_refresh || !cache_exists {
         debug!(


### PR DESCRIPTION
Initial code to implement caching as described in #13 .
This code currently just has a placeholder for grabbing the CLI refresh cache argument (Lines 226-227 in the diff of `src/x86_parser.rs` below) which can be swapped out with the way the project typically handles CLI args. 

Closes #13 