### PR TITLE
Fix x86 online docs regex, removing extra /x86/

### DIFF
--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -234,7 +234,8 @@ pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instructi
     //
     // let re = Regex::new(r"<a href=\"./(.*)">(.*)</a></td>")?;
     // let re = Regex::new(r#"<a href="\./(.*?\.html)">(.*?)</a>.*</td>"#)?;
-    let re = Regex::new(r"<a href='\/(.*?)'>(.*?)<\/a>.*<\/td>")?;
+    // let re = Regex::new(r"<a href='\/(.*?)'>(.*?)<\/a>.*<\/td>")?;
+    let re = Regex::new(r"<a href='\/x86\/(.*?)'>(.*?)<\/a>.*<\/td>")?;
     for line in body_it {
         // take it step by step.. match a small portion of the line first...
         let caps = re.captures(line).unwrap();


### PR DESCRIPTION
I noticed the regex used to parse the online docs was adding an extra /x86/ to the hover window's displayed url, yielding an invalid link. 
Before:
![image](https://github.com/bergercookie/asm-lsp/assets/87077023/fe39da0c-43eb-4831-b052-61f8aba93413)
Link yielded: https://www.felixcloutier.com/x86/x86/pop

After:
![image](https://github.com/bergercookie/asm-lsp/assets/87077023/b226e06f-3dc4-47c0-9a4c-e7410f7ccf41)
Link yielded: https://www.felixcloutier.com/x86/pop

I fixed this by adding x86/ explicitly into the regex, moving it out of the capture group used for the `url_suffix` variable initialized at `src/x86_parser.rs` line 242  in the diff. The old regex is left in the file (commented out) for reference.

Closes #19 