### PR TITLE
chore: update Cargo lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "asm-lsp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "flexi_logger",


### PR DESCRIPTION
Updates the out-of-date cargo lock. 

Unblocks `nixpkgs` packaging.