### PR TITLE
Fix case sensitivity issue with intel syntax instruction names

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -120,10 +120,9 @@ fn main_loop(
                         // format response
                         match word {
                             Ok(word) => {
-                                let (x86_instruction, x86_64_instruction) = (
-                                    names_to_instructions.get(&(Arch::X86, &*word)),
-                                    names_to_instructions.get(&(Arch::X86_64, &*word)),
-                                );
+                                let (x86_instruction, x86_64_instruction) =
+                                    search_for_instr(&word, names_to_instructions);
+
                                 let hover_res: Option<Hover> =
                                     match (x86_instruction.is_some(), x86_64_instruction.is_some())
                                     {


### PR DESCRIPTION
Fixes the behavior mentioned in #23 where intel syntax instruction names have hover support only if they aren't capitalized. E.g., ``MOV`` would work but ``mov`` would not. 