### PR TITLE
Add register hover support

### DIFF
--- a/registers/x86.xml
+++ b/registers/x86.xml
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='utf-8'?>
+<InstructionSet name="x86">
+    <Register name="rax" description="Accumulator" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="eax" description="Accumulator" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="ax" description="Accumulator" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="ah" description="Accumulator" type="GeneralPurpose" location="8-high-bits">
+    </Register>
+    <Register name="al" description="Accumulator" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rbx" description="Base" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="ebx" description="Base" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="bx" description="Base" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="bh" description="Base" type="GeneralPurpose" location="8-high-bits">
+    </Register>
+    <Register name="bl" description="Base" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rcx" description="Counter" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="ecx" description="Counter" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="cx" description="Counter" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="ch" description="Counter" type="GeneralPurpose" location="8-high-bits">
+    </Register>
+    <Register name="cl" description="Counter" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rdx" description="Data" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="edx" description="Data" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="dx" description="Data" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="dh" description="Data" type="GeneralPurpose" location="8-high-bits">
+    </Register>
+    <Register name="dl" description="Data" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rsi" description="Source" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="esi" description="Source" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="si" description="Source" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="sil" description="Source" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rdi" description="Destination" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="edi" description="Destination" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="di" description="Destination" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="dil" description="Destination" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rsp" description="Stack Pointer" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="esp" description="Stack Pointer" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="sp" description="Stack Pointer" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="spl" description="Stack Pointer" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+    <Register name="rbp" description="Stack Base Pointer" type="GeneralPurpose" location="64-bit">
+    </Register>
+    <Register name="ebp" description="Stack Base Pointer" type="GeneralPurpose" location="32-bit">
+    </Register>
+    <Register name="bp" description="Stack Base Pointer" type="GeneralPurpose" location="16-bit">
+    </Register>
+    <Register name="bpl" description="Stack Base Pointer" type="GeneralPurpose" location="8-low-bits">
+    </Register>
+</InstructionSet>

--- a/registers/x86.xml
+++ b/registers/x86.xml
@@ -1,75 +1,685 @@
 <?xml version='1.0' encoding='utf-8'?>
 <InstructionSet name="x86">
-    <Register name="rax" description="Accumulator" type="GeneralPurpose" location="64-bit">
+    <Register name="rax" description="Accumulator" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="eax" description="Accumulator" type="GeneralPurpose" location="32-bit">
+    <Register name="eax" description="Accumulator" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="ax" description="Accumulator" type="GeneralPurpose" location="16-bit">
+    <Register name="ax" description="Accumulator" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="ah" description="Accumulator" type="GeneralPurpose" location="8-high-bits">
+    <Register name="ah" description="Accumulator" type="General Purpose Register" width="8 high bits of lower 16 bits">
     </Register>
-    <Register name="al" description="Accumulator" type="GeneralPurpose" location="8-low-bits">
+    <Register name="al" description="Accumulator" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rbx" description="Base" type="GeneralPurpose" location="64-bit">
+    <Register name="rbx" description="Base" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="ebx" description="Base" type="GeneralPurpose" location="32-bit">
+    <Register name="ebx" description="Base" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="bx" description="Base" type="GeneralPurpose" location="16-bit">
+    <Register name="bx" description="Base" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="bh" description="Base" type="GeneralPurpose" location="8-high-bits">
+    <Register name="bh" description="Base" type="General Purpose Register" width="8 high bits of lower 16 bits">
     </Register>
-    <Register name="bl" description="Base" type="GeneralPurpose" location="8-low-bits">
+    <Register name="bl" description="Base" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rcx" description="Counter" type="GeneralPurpose" location="64-bit">
+    <Register name="rcx" description="Counter" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="ecx" description="Counter" type="GeneralPurpose" location="32-bit">
+    <Register name="ecx" description="Counter" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="cx" description="Counter" type="GeneralPurpose" location="16-bit">
+    <Register name="cx" description="Counter" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="ch" description="Counter" type="GeneralPurpose" location="8-high-bits">
+    <Register name="ch" description="Counter" type="General Purpose Register" width="8 high bits of lower 16 bits">
     </Register>
-    <Register name="cl" description="Counter" type="GeneralPurpose" location="8-low-bits">
+    <Register name="cl" description="Counter" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rdx" description="Data" type="GeneralPurpose" location="64-bit">
+    <Register name="rdx" description="Data" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="edx" description="Data" type="GeneralPurpose" location="32-bit">
+    <Register name="edx" description="Data" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="dx" description="Data" type="GeneralPurpose" location="16-bit">
+    <Register name="dx" description="Data" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="dh" description="Data" type="GeneralPurpose" location="8-high-bits">
+    <Register name="dh" description="Data" type="General Purpose Register" width="8 high bits of lower 16 bits">
     </Register>
-    <Register name="dl" description="Data" type="GeneralPurpose" location="8-low-bits">
+    <Register name="dl" description="Data" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rsi" description="Source" type="GeneralPurpose" location="64-bit">
+    <Register name="rsi" description="Source" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="esi" description="Source" type="GeneralPurpose" location="32-bit">
+    <Register name="esi" description="Source" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="si" description="Source" type="GeneralPurpose" location="16-bit">
+    <Register name="si" description="Source" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="sil" description="Source" type="GeneralPurpose" location="8-low-bits">
+    <Register name="sil" description="Source" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rdi" description="Destination" type="GeneralPurpose" location="64-bit">
+    <Register name="rdi" description="Destination" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="edi" description="Destination" type="GeneralPurpose" location="32-bit">
+    <Register name="edi" description="Destination" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="di" description="Destination" type="GeneralPurpose" location="16-bit">
+    <Register name="di" description="Destination" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="dil" description="Destination" type="GeneralPurpose" location="8-low-bits">
+    <Register name="dil" description="Destination" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rsp" description="Stack Pointer" type="GeneralPurpose" location="64-bit">
+    <Register name="rsp" description="Stack Pointer" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="esp" description="Stack Pointer" type="GeneralPurpose" location="32-bit">
+    <Register name="esp" description="Stack Pointer" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="sp" description="Stack Pointer" type="GeneralPurpose" location="16-bit">
+    <Register name="sp" description="Stack Pointer" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="spl" description="Stack Pointer" type="GeneralPurpose" location="8-low-bits">
+    <Register name="spl" description="Stack Pointer" type="General Purpose Register" width="8 lower bits">
     </Register>
-    <Register name="rbp" description="Stack Base Pointer" type="GeneralPurpose" location="64-bit">
+    <Register name="rbp" description="Stack Base Pointer" type="General Purpose Register" width="64 bits">
     </Register>
-    <Register name="ebp" description="Stack Base Pointer" type="GeneralPurpose" location="32-bit">
+    <Register name="ebp" description="Stack Base Pointer" type="General Purpose Register" width="32 bits">
     </Register>
-    <Register name="bp" description="Stack Base Pointer" type="GeneralPurpose" location="16-bit">
+    <Register name="bp" description="Stack Base Pointer" type="General Purpose Register" width="16 bits">
     </Register>
-    <Register name="bpl" description="Stack Base Pointer" type="GeneralPurpose" location="8-low-bits">
+    <Register name="bpl" description="Stack Base Pointer" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rip" description="Instruction Pointer" type="Pointer Register" width="64 bits">
+    </Register>
+    <Register name="eip" description="Instruction Pointer" type="Pointer Register" width="32 bits">
+    </Register>
+    <Register name="ip" description="Instruction Pointer" type="Pointer Register" width="16 bits">
+    </Register>
+    <Register name="cs" description="Code Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="ds" description="Data Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="es" description="Extra Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="ss" description="Stack Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="fs" description="General Purpose F Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="gs" description="General Purpose G Segment" type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="eflags" description="Extended Flags Register" type="Flag Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="CF" description="Carry flag"></Flag>
+            <Flag bit="1" label="" description="Reserved"></Flag>
+            <Flag bit="2" label="PF" description="Parity flag"></Flag>
+            <Flag bit="3" label="" description="Reserved"></Flag>
+            <Flag bit="4" label="AF" description="Auxiliary flag"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="ZF" description="Zero flag"></Flag>
+            <Flag bit="7" label="SF" description="Sign flag"></Flag>
+            <Flag bit="8" label="TF" description="Trap flag"></Flag>
+            <Flag bit="9" label="IF" description="Interrupt enable flag"></Flag>
+            <Flag bit="10" label="DF" description="Direction flag"></Flag>
+            <Flag bit="11" label="OF" description="Overflow flag"></Flag>
+            <Flag bit="12" label="IOPL" description="I/O privilege level"></Flag>
+            <Flag bit="13" label="IOPL" description="I/O privilege level"></Flag>
+            <Flag bit="14" label="NT" description="Nested task flag"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="RF" description="Resume flag"></Flag>
+            <Flag bit="17" label="VM" description="Virtual 8086 mode flag"></Flag>
+            <Flag bit="18" label="AC" description="Alignment check"></Flag>
+            <Flag bit="19" label="VIF" description="Virtual interrupt flag"></Flag>
+            <Flag bit="20" label="VIP" description="Virtual interrupt pending"></Flag>
+            <Flag bit="21" label="ID" description="Able to use CPUID instruction"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr0" description="Control Register 0" type="Control Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="PE" description="Protected Mode Enable"></Flag>
+            <Flag bit="1" label="MP" description="Monitor co-processor"></Flag>
+            <Flag bit="2" label="EM" description="x87 FPU Emulation"></Flag>
+            <Flag bit="3" label="TS" description="Task switched"></Flag>
+            <Flag bit="4" label="ET" description="Extension type"></Flag>
+            <Flag bit="5" label="NE" description="Numeric error"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="WP" description="Write protect"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="AM" description="Alignment mask"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="NW" description="Not-write through"></Flag>
+            <Flag bit="30" label="CD" description="Cache disable"></Flag>
+            <Flag bit="31" label="PG" description="Paging"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr1" description="Reserved" type="Control Register">
+    </Register>
+    <Register name="cr2" description="Control Register 2. Page Fault Linear Address" type="Control Register" width="32(64) bits">
+    </Register>
+    <Register name="cr3" description="Control Register 3" type="Control Register">
+        <Flags>
+            <Flag bit="0" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="1" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="2" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="3" label="PWT" description="Page-level Write-Through" pae="(Not Used)" longmode="Not used if bit 17 of CR4 is 1"></Flag>
+            <Flag bit="4" label="PCD" description="Page-level Cache Disable" pae="(Not Used)" longmode="Not used if bit 17 of CR4 is 1"></Flag>
+            <Flag bit="5" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="6" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="7" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="8" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="9" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="10" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="11" label="" description="Assumed to be 0"></Flag>
+            <Flag bit="12" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="13" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="14" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="15" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="16" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="17" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="18" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="19" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="20" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="21" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="22" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="23" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="24" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="25" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="26" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="27" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="28" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="29" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="30" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="31" label="PDBR" description="Page Directory Base Register" pae="Base of PDPT" longmode="Base of PMLT4/PML5T"></Flag>
+            <Flag bit="32" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="33" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="34" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="35" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="36" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="37" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="38" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="39" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="40" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="41" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="42" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="43" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="44" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="45" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="46" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="47" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="48" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="49" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="50" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="51" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="52" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="53" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="54" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="55" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="56" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="57" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="58" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="59" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="60" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="61" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="62" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+            <Flag bit="63" label="PDBR" description="(Page Directory Base Register)" pae="(Base of PDPT)" longmode="(Base of PMLT4/PML5T)"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr4" description="Control Register 4" type="Control Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="VME" description="Virtual 8086 Mode Extensions"></Flag>
+            <Flag bit="1" label="PVI" description="Protected-mode Virtual Interrupts"></Flag>
+            <Flag bit="2" label="TSD" description="Time Stamp Disable"></Flag>
+            <Flag bit="3" label="DE" description="Debugging Extensions"></Flag>
+            <Flag bit="4" label="PSE" description="Page Size Extension"></Flag>
+            <Flag bit="5" label="PAE" description="Physical Address Extension"></Flag>
+            <Flag bit="6" label="MCE" description="Machine Check Exception"></Flag>
+            <Flag bit="7" label="PGE" description="Page Global Enabled"></Flag>
+            <Flag bit="8" label="PCE" description="Performance-Monitoring Counter enable"></Flag>
+            <Flag bit="9" label="OSFXSR" description="Operating system support for FXSAVE and FXRSTOR operations"></Flag>
+            <Flag bit="10" label="OSXMMEXCPT" description="Operating System Support for Unmasked SIMD Floating-Point Exceptions"></Flag>
+            <Flag bit="11" label="UMIP" description="User-Mode Instruction Prevention (if set, #GP on SGDT, SIDT, SLDT, SMSW, and STR instructions when CPL>0)"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="VMXE" description="Virtual Machine Extensions Enable"></Flag>
+            <Flag bit="14" label="SMXE" description="Safer Mode Extensions Enable"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="FSGSBASE" description="Enables the instructions RDFSBASE, RDGSBASE, WRFSBASE, and WRGSBASE"></Flag>
+            <Flag bit="17" label="PCIDE" description="PCID Enable"></Flag>
+            <Flag bit="18" label="OSXSAVE" description="XSAVE and Processor Extended States Enable"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="SMEP" description="Supervisor Mode Execution Protection Enable"></Flag>
+            <Flag bit="21" label="SMAP" description="Supervisor Modde Access Prevention Enable"></Flag>
+            <Flag bit="22" label="PKE" description="Protection Key Enable"></Flag>
+            <Flag bit="23" label="CET" description="Control-flow Enforcement Technology"></Flag>
+            <Flag bit="24" label="PKS" description="Enable Protection Keys for Supervisor-Mode Pages"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr5" description="Reserved" type="Control Register">
+    </Register>
+    <Register name="cr6" description="Reserved" type="Control Register">
+    </Register>
+    <Register name="cr7" description="Reserved" type="Control Register">
+    </Register>
+    <Register name="cr8" description="Control Register 8" type="Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="TPL" description="Task Priority Level"></Flag>
+            <Flag bit="1" label="TPL" description="Task Priority Level"></Flag>
+            <Flag bit="2" label="TPL" description="Task Priority Level"></Flag>
+            <Flag bit="3" label="TPL" description="Task Priority Level"></Flag>
+            <Flag bit="4" label="" description="Reserved"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="" description="Reserved"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="" description="Reserved"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="(Reserved)"></Flag>
+            <Flag bit="33" label="" description="(Reserved)"></Flag>
+            <Flag bit="34" label="" description="(Reserved)"></Flag>
+            <Flag bit="35" label="" description="(Reserved)"></Flag>
+            <Flag bit="36" label="" description="(Reserved)"></Flag>
+            <Flag bit="37" label="" description="(Reserved)"></Flag>
+            <Flag bit="38" label="" description="(Reserved)"></Flag>
+            <Flag bit="39" label="" description="(Reserved)"></Flag>
+            <Flag bit="40" label="" description="(Reserved)"></Flag>
+            <Flag bit="41" label="" description="(Reserved)"></Flag>
+            <Flag bit="42" label="" description="(Reserved)"></Flag>
+            <Flag bit="43" label="" description="(Reserved)"></Flag>
+            <Flag bit="44" label="" description="(Reserved)"></Flag>
+            <Flag bit="45" label="" description="(Reserved)"></Flag>
+            <Flag bit="46" label="" description="(Reserved)"></Flag>
+            <Flag bit="47" label="" description="(Reserved)"></Flag>
+            <Flag bit="48" label="" description="(Reserved)"></Flag>
+            <Flag bit="49" label="" description="(Reserved)"></Flag>
+            <Flag bit="50" label="" description="(Reserved)"></Flag>
+            <Flag bit="51" label="" description="(Reserved)"></Flag>
+            <Flag bit="52" label="" description="(Reserved)"></Flag>
+            <Flag bit="53" label="" description="(Reserved)"></Flag>
+            <Flag bit="54" label="" description="(Reserved)"></Flag>
+            <Flag bit="55" label="" description="(Reserved)"></Flag>
+            <Flag bit="56" label="" description="(Reserved)"></Flag>
+            <Flag bit="57" label="" description="(Reserved)"></Flag>
+            <Flag bit="58" label="" description="(Reserved)"></Flag>
+            <Flag bit="59" label="" description="(Reserved)"></Flag>
+            <Flag bit="60" label="" description="(Reserved)"></Flag>
+            <Flag bit="61" label="" description="(Reserved)"></Flag>
+            <Flag bit="62" label="" description="(Reserved)"></Flag>
+            <Flag bit="63" label="" description="(Reserved)"></Flag>
+        </Flags>
+    </Register>
+    <Register name="xcr0" description="Can only be accessed if bit 18 of CR4 is set to 1. XGETBV and XSETBV instructions are used to access XCR0" type="Extended Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="X87" description="x87 FPU/MMX support (must be 1)"></Flag>
+            <Flag bit="1" label="SSE" description="XSAVE support for MXCSR and XMM registers"></Flag>
+            <Flag bit="2" label="AVX" description="AVX enabled and XSAVE support for upper halves of YMM registers"></Flag>
+            <Flag bit="3" label="BNDREG" description="MPX enabled and XSAVE support for BND0-BND3 registers"></Flag>
+            <Flag bit="4" label="BNDCSR" description="MPX enabled and XSAVE support for BNDCFGU and BNDSATUS registers"></Flag>
+            <Flag bit="5" label="opmask" description="AVX-512 enabled and XSAVE support for opmask registers k0-k7"></Flag>
+            <Flag bit="6" label="ZMM_Hi256" description="AVX-512 enabled and XSAVE support for upper halves of lower ZMM registers"></Flag>
+            <Flag bit="7" label="Hi16_ZMM" description="AVX-512 enabled and XSAVE support for upper ZMM registers"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="PKRU" description="XSAVE support for PKRU register"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="" description="Reserved"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="" description="Reserved"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="(Reserved)"></Flag>
+            <Flag bit="33" label="" description="(Reserved)"></Flag>
+            <Flag bit="34" label="" description="(Reserved)"></Flag>
+            <Flag bit="35" label="" description="(Reserved)"></Flag>
+            <Flag bit="36" label="" description="(Reserved)"></Flag>
+            <Flag bit="37" label="" description="(Reserved)"></Flag>
+            <Flag bit="38" label="" description="(Reserved)"></Flag>
+            <Flag bit="39" label="" description="(Reserved)"></Flag>
+            <Flag bit="40" label="" description="(Reserved)"></Flag>
+            <Flag bit="41" label="" description="(Reserved)"></Flag>
+            <Flag bit="42" label="" description="(Reserved)"></Flag>
+            <Flag bit="43" label="" description="(Reserved)"></Flag>
+            <Flag bit="44" label="" description="(Reserved)"></Flag>
+            <Flag bit="45" label="" description="(Reserved)"></Flag>
+            <Flag bit="46" label="" description="(Reserved)"></Flag>
+            <Flag bit="47" label="" description="(Reserved)"></Flag>
+            <Flag bit="48" label="" description="(Reserved)"></Flag>
+            <Flag bit="49" label="" description="(Reserved)"></Flag>
+            <Flag bit="50" label="" description="(Reserved)"></Flag>
+            <Flag bit="51" label="" description="(Reserved)"></Flag>
+            <Flag bit="52" label="" description="(Reserved)"></Flag>
+            <Flag bit="53" label="" description="(Reserved)"></Flag>
+            <Flag bit="54" label="" description="(Reserved)"></Flag>
+            <Flag bit="55" label="" description="(Reserved)"></Flag>
+            <Flag bit="56" label="" description="(Reserved)"></Flag>
+            <Flag bit="57" label="" description="(Reserved)"></Flag>
+            <Flag bit="58" label="" description="(Reserved)"></Flag>
+            <Flag bit="59" label="" description="(Reserved)"></Flag>
+            <Flag bit="60" label="" description="(Reserved)"></Flag>
+            <Flag bit="61" label="" description="(Reserved)"></Flag>
+            <Flag bit="62" label="" description="(Reserved)"></Flag>
+            <Flag bit="63" label="" description="(Reserved)"></Flag>
+        </Flags>
+    </Register>
+    <Register name="dr0" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register" width="32 bits">
+    </Register>
+    <Register name="dr1" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register" width="32 bits">
+    </Register>
+    <Register name="dr2" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register" width="32 bits">
+    </Register>
+    <Register name="dr3" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register" width="32 bits">
+    </Register>
+    <Register name="dr6" description="Permits the debugger to determine which debug conditions have occurred" type="Debug Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="" description="Indicates, when set, that the associated breakpoint condition was met when a debug exception was generated"></Flag>
+            <Flag bit="1" label="" description="Indicates, when set, that the associated breakpoint condition was met when a debug exception was generated"></Flag>
+            <Flag bit="2" label="" description="Indicates, when set, that the associated breakpoint condition was met when a debug exception was generated"></Flag>
+            <Flag bit="3" label="" description="Indicates, when set, that the associated breakpoint condition was met when a debug exception was generated"></Flag>
+            <Flag bit="4" label="" description="Reserved"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Indicates that the next instruction in the instruction stream accesses one of the debug registers"></Flag>
+            <Flag bit="14" label="" description="Indicates, when set, that the debug exception was triggered by the single-step execution mode (enabled with TF bit in EFLAGS)"></Flag>
+            <Flag bit="15" label="" description="Indicates, when set, that the debug instruction resulted from a task switch where T flag in the TSS of target task was set"></Flag>
+            <Flag bit="16" label="" description="Indicates, when set, that the debug exception or breakpoint occurred inside an RTM region"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="" description="Reserved"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="dr7" description="A local breakpoint bit deactivates on hardware task switches, while a global does not. Condition 00b means execution break, 01b means a write watchpoint, and 11b means a R/W watchpoint. 10b is reserved for I/O R/W (unsupported)" type="Debug Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="" description="Local DR0 breakpoint"></Flag>
+            <Flag bit="1" label="" description="Global DR0 breakpoint"></Flag>
+            <Flag bit="2" label="" description="Local DR1 breakpoint"></Flag>
+            <Flag bit="3" label="" description="Global DR1 breakpoint"></Flag>
+            <Flag bit="4" label="" description="Local DR2 breakpoint"></Flag>
+            <Flag bit="5" label="" description="Global DR2 breakpoint"></Flag>
+            <Flag bit="6" label="" description="Local DR3 breakpoint"></Flag>
+            <Flag bit="7" label="" description="Global DR3 breakpoint"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="" description="Condition for DR0"></Flag>
+            <Flag bit="17" label="" description="Condition for DR0"></Flag>
+            <Flag bit="18" label="" description="Size of DR0 breakpoint"></Flag>
+            <Flag bit="19" label="" description="Size of DR0 breakpoint"></Flag>
+            <Flag bit="20" label="" description="Condition for DR1"></Flag>
+            <Flag bit="21" label="" description="Condition for DR1"></Flag>
+            <Flag bit="22" label="" description="Size of DR1 breakpoint"></Flag>
+            <Flag bit="23" label="" description="Size of DR1 breakpoint"></Flag>
+            <Flag bit="24" label="" description="Condition for DR2"></Flag>
+            <Flag bit="25" label="" description="Condition for DR2"></Flag>
+            <Flag bit="26" label="" description="Size of DR2 breakpoint"></Flag>
+            <Flag bit="27" label="" description="Size of DR2 breakpoint"></Flag>
+            <Flag bit="28" label="" description="Condition for DR3"></Flag>
+            <Flag bit="29" label="" description="Condition for DR3"></Flag>
+            <Flag bit="30" label="" description="Size of DR3 breakpoint"></Flag>
+            <Flag bit="31" label="" description="Size of DR3 breakpoint"></Flag>
+        </Flags>
+    </Register>
+    <Register name="tr3" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr4" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr5" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr6" description="Test command register" type="Test Register">
+    </Register>
+    <Register name="tr7" description="Test data register" type="Test Register">
+    </Register>
+    <Register name="gdtr" description="Stores the segment selector of the GDT" type="Protected Mode Register" width="48 bits">
+        <Flags>
+            <Flag bit="0" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="1" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="2" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="3" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="4" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="5" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="6" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="7" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="8" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="9" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="10" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="11" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="12" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="13" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="14" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="15" label="Limit" description="(Size of GDT) - 1"></Flag>
+            <Flag bit="16" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="17" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="18" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="19" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="20" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="21" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="22" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="23" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="24" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="25" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="26" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="27" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="28" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="29" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="30" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="31" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="32" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="33" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="34" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="35" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="36" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="37" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="38" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="39" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="40" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="41" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="42" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="43" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="44" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="45" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="46" label="Base" description="Starting address of GDT"></Flag>
+            <Flag bit="47" label="Base" description="Starting address of GDT"></Flag>
+        </Flags>
+    </Register>
+    <Register name="ldtr" description="Stores the segment selector of the LDT" type="Protected Mode Register" width="48 bits">
+        <Flags>
+            <Flag bit="0" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="1" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="2" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="3" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="4" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="5" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="6" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="7" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="8" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="9" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="10" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="11" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="12" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="13" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="14" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="15" label="Limit" description="(Size of LDT) - 1"></Flag>
+            <Flag bit="16" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="17" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="18" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="19" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="20" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="21" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="22" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="23" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="24" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="25" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="26" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="27" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="28" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="29" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="30" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="31" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="32" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="33" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="34" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="35" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="36" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="37" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="38" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="39" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="40" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="41" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="42" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="43" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="44" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="45" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="46" label="Base" description="Starting address of LDT"></Flag>
+            <Flag bit="47" label="Base" description="Starting address of LDT"></Flag>
+        </Flags>
+    </Register>
+    <Register name="idtr" description="Stores the segment selector of the IDT" type="Protected Mode Register" width="48 bits">
+        <Flags>
+            <Flag bit="0" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="1" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="2" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="3" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="4" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="5" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="6" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="7" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="8" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="9" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="10" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="11" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="12" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="13" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="14" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="15" label="Limit" description="(Size of IDT) - 1"></Flag>
+            <Flag bit="16" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="17" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="18" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="19" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="20" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="21" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="22" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="23" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="24" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="25" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="26" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="27" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="28" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="29" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="30" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="31" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="32" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="33" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="34" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="35" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="36" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="37" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="38" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="39" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="40" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="41" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="42" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="43" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="44" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="45" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="46" label="Base" description="Starting address of IDT"></Flag>
+            <Flag bit="47" label="Base" description="Starting address of IDT"></Flag>
+        </Flags>
+    </Register>
+    <Register name="xmm0" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm1" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm2" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm3" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm4" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm5" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm6" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm7" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
     </Register>
 </InstructionSet>

--- a/registers/x86_64.xml
+++ b/registers/x86_64.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<InstructionSet name="x86_64">
+    <Register name="rax" description="Accumulator" type="GeneralPurpose" location="64-bit">
+    </Register>
+</InstructionSet>

--- a/registers/x86_64.xml
+++ b/registers/x86_64.xml
@@ -1,5 +1,1125 @@
 <?xml version='1.0' encoding='utf-8'?>
 <InstructionSet name="x86_64">
-    <Register name="rax" description="Accumulator" type="GeneralPurpose" location="64-bit">
+    <Register name="rax" description="Accumulator" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="eax" description="Accumulator" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="ax" description="Accumulator" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="ah" description="Accumulator. Cannot be accessed when using the REX.W instruction prefix. The prefixed is added (automatically by assemblers) when an operand contains a 64-bit register" type="General Purpose Register" width="8 high bits of lower 16 bits">
+    </Register>
+    <Register name="al" description="Accumulator" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rbx" description="Base" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="ebx" description="Base" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="bx" description="Base" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="bh" description="Base. Cannot be accessed when using the REX.W instruction prefix. The prefixed is added (automatically by assemblers) when an operand contains a 64-bit register" type="General Purpose Register" width="8 high bits of lower 16 bits">
+    </Register>
+    <Register name="bl" description="Base" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rcx" description="Counter" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="ecx" description="Counter" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="cx" description="Counter" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="ch" description="Counter. Cannot be accessed when using the REX.W instruction prefix. The prefixed is added (automatically by assemblers) when an operand contains a 64-bit register" type="General Purpose Register" width="8 high bits of lower 16 bits">
+    </Register>
+    <Register name="cl" description="Counter" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rdx" description="Data (commonly extends the A register)" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="edx" description="Data (commonly extends the A register)" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="dx" description="Data (commonly extends the A register)" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="dh" description="Data (commonly extends the A register). Cannot be accessed when using the REX.W instruction prefix. The prefixed is added (automatically by assemblers) when an operand contains a 64-bit register" type="General Purpose Register" width="8 high bits of lower 16 bits">
+    </Register>
+    <Register name="dl" description="Data (commonly extends the A register)" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rsi" description="Source index for string operations" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="esi" description="Source index for string operations" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="si" description="Source index for string operations" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="sil" description="Source index for string operations" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rdi" description="Destination index for string operations" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="edi" description="Destination index for string operations" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="di" description="Destination index for string operations" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="dil" description="Destination index for string operations" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rsp" description="Stack Pointer" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="esp" description="Stack Pointer" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="sp" description="Stack Pointer" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="spl" description="Stack Pointer" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rbp" description="Base Pointer (meant for stack frames)" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="ebp" description="Base Pointer (meant for stack frames)" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="bp" description="Base Pointer (meant for stack frames)" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="bpl" description="Base Pointer (meant for stack frames)" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r8" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r8d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r8w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r8b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r9" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r9d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r9w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r9b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r10" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r10d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r10w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r10b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r11" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r11d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r11w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r11b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r12" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r12d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r12w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r12b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r13" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r13d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r13w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r13b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r14" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r14d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r14w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r14b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="r15" description="General Purpose" type="General Purpose Register" width="64 bits">
+    </Register>
+    <Register name="r15d" description="General Purpose" type="General Purpose Register" width="32 bits">
+    </Register>
+    <Register name="r15w" description="General Purpose" type="General Purpose Register" width="16 bits">
+    </Register>
+    <Register name="r15b" description="General Purpose" type="General Purpose Register" width="8 lower bits">
+    </Register>
+    <Register name="rip" description="Instruction Pointer. Can only be used in RIP-relative addressing." type="Pointer Register" width="64 bits">
+    </Register>
+    <Register name="eip" description="Instruction Pointer. Can only be used in RIP-relative addressing." type="Pointer Register" width="32 bits">
+    </Register>
+    <Register name="ip" description="Instruction Pointer. Can only be used in RIP-relative addressing." type="Pointer Register" width="16 bits">
+    </Register>
+    <Register name="cs" description="Code Segment. Treated as if its base is 0 no matter what the segment descriptors in the GDT say." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="ds" description="Data Segment. Treated as if its base is 0 no matter what the segment descriptors in the GDT say." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="ss" description="Stack Segment. Treated as if its base is 0 no matter what the segment descriptors in the GDT say." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="es" description="Extra Segment (used for string operations). Treated as if its base is 0 no matter what the segment descriptors in the GDT say." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="fs" description="General Purpose F Segment. MSRs can change its base." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="gs" description="General Purpose G Segment. MSRs can change its base." type="Segment Register" width="16 bits">
+    </Register>
+    <Register name="rflags" description="Reserved Flags Register" type="Flag Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="CF" description="Carry flag"></Flag>
+            <Flag bit="1" label="" description="Reserved"></Flag>
+            <Flag bit="2" label="PF" description="Parity flag"></Flag>
+            <Flag bit="3" label="" description="Reserved"></Flag>
+            <Flag bit="4" label="AF" description="Auxiliary Carry flag"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="ZF" description="Zero flag"></Flag>
+            <Flag bit="7" label="SF" description="Sign flag"></Flag>
+            <Flag bit="8" label="TF" description="Trap flag"></Flag>
+            <Flag bit="9" label="IF" description="Interrupt enable flag"></Flag>
+            <Flag bit="10" label="DF" description="Direction flag"></Flag>
+            <Flag bit="11" label="OF" description="Overflow flag"></Flag>
+            <Flag bit="12" label="IOPL" description="I/O privilege level"></Flag>
+            <Flag bit="13" label="IOPL" description="I/O privilege level"></Flag>
+            <Flag bit="14" label="NT" description="Nested task flag"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="RF" description="Resume flag"></Flag>
+            <Flag bit="17" label="VM" description="Virtual 8086 mode flag"></Flag>
+            <Flag bit="18" label="AC" description="Alignment check"></Flag>
+            <Flag bit="19" label="VIF" description="Virtual interrupt flag"></Flag>
+            <Flag bit="20" label="VIP" description="Virtual interrupt pending"></Flag>
+            <Flag bit="21" label="ID" description="Able to use CPUID instruction"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="Reserved"></Flag>
+            <Flag bit="33" label="" description="Reserved"></Flag>
+            <Flag bit="34" label="" description="Reserved"></Flag>
+            <Flag bit="35" label="" description="Reserved"></Flag>
+            <Flag bit="36" label="" description="Reserved"></Flag>
+            <Flag bit="37" label="" description="Reserved"></Flag>
+            <Flag bit="38" label="" description="Reserved"></Flag>
+            <Flag bit="39" label="" description="Reserved"></Flag>
+            <Flag bit="40" label="" description="Reserved"></Flag>
+            <Flag bit="41" label="" description="Reserved"></Flag>
+            <Flag bit="42" label="" description="Reserved"></Flag>
+            <Flag bit="43" label="" description="Reserved"></Flag>
+            <Flag bit="44" label="" description="Reserved"></Flag>
+            <Flag bit="45" label="" description="Reserved"></Flag>
+            <Flag bit="46" label="" description="Reserved"></Flag>
+            <Flag bit="47" label="" description="Reserved"></Flag>
+            <Flag bit="48" label="" description="Reserved"></Flag>
+            <Flag bit="49" label="" description="Reserved"></Flag>
+            <Flag bit="50" label="" description="Reserved"></Flag>
+            <Flag bit="51" label="" description="Reserved"></Flag>
+            <Flag bit="52" label="" description="Reserved"></Flag>
+            <Flag bit="53" label="" description="Reserved"></Flag>
+            <Flag bit="54" label="" description="Reserved"></Flag>
+            <Flag bit="55" label="" description="Reserved"></Flag>
+            <Flag bit="56" label="" description="Reserved"></Flag>
+            <Flag bit="57" label="" description="Reserved"></Flag>
+            <Flag bit="58" label="" description="Reserved"></Flag>
+            <Flag bit="59" label="" description="Reserved"></Flag>
+            <Flag bit="60" label="" description="Reserved"></Flag>
+            <Flag bit="61" label="" description="Reserved"></Flag>
+            <Flag bit="62" label="" description="Reserved"></Flag>
+            <Flag bit="63" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr0" description="Control Register 0. This is the only control register that can be written and read via 2 ways unlike the others that can be accessed only via the MOV instruction." type="Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="PE" description="Protected Mode Enable"></Flag>
+            <Flag bit="1" label="MP" description="Monitor co-processor"></Flag>
+            <Flag bit="2" label="EM" description="x87 FPU Emulation"></Flag>
+            <Flag bit="3" label="TS" description="Task switched"></Flag>
+            <Flag bit="4" label="ET" description="Extension type"></Flag>
+            <Flag bit="5" label="NE" description="Numeric error"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="WP" description="Write protect"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="AM" description="Alignment mask"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="NW" description="Not-write through"></Flag>
+            <Flag bit="30" label="CD" description="Cache disable"></Flag>
+            <Flag bit="31" label="PG" description="Paging"></Flag>
+            <Flag bit="32" label="" description="Reserved"></Flag>
+            <Flag bit="33" label="" description="Reserved"></Flag>
+            <Flag bit="34" label="" description="Reserved"></Flag>
+            <Flag bit="35" label="" description="Reserved"></Flag>
+            <Flag bit="36" label="" description="Reserved"></Flag>
+            <Flag bit="37" label="" description="Reserved"></Flag>
+            <Flag bit="38" label="" description="Reserved"></Flag>
+            <Flag bit="39" label="" description="Reserved"></Flag>
+            <Flag bit="40" label="" description="Reserved"></Flag>
+            <Flag bit="41" label="" description="Reserved"></Flag>
+            <Flag bit="42" label="" description="Reserved"></Flag>
+            <Flag bit="43" label="" description="Reserved"></Flag>
+            <Flag bit="44" label="" description="Reserved"></Flag>
+            <Flag bit="45" label="" description="Reserved"></Flag>
+            <Flag bit="46" label="" description="Reserved"></Flag>
+            <Flag bit="47" label="" description="Reserved"></Flag>
+            <Flag bit="48" label="" description="Reserved"></Flag>
+            <Flag bit="49" label="" description="Reserved"></Flag>
+            <Flag bit="50" label="" description="Reserved"></Flag>
+            <Flag bit="51" label="" description="Reserved"></Flag>
+            <Flag bit="52" label="" description="Reserved"></Flag>
+            <Flag bit="53" label="" description="Reserved"></Flag>
+            <Flag bit="54" label="" description="Reserved"></Flag>
+            <Flag bit="55" label="" description="Reserved"></Flag>
+            <Flag bit="56" label="" description="Reserved"></Flag>
+            <Flag bit="57" label="" description="Reserved"></Flag>
+            <Flag bit="58" label="" description="Reserved"></Flag>
+            <Flag bit="59" label="" description="Reserved"></Flag>
+            <Flag bit="60" label="" description="Reserved"></Flag>
+            <Flag bit="61" label="" description="Reserved"></Flag>
+            <Flag bit="62" label="" description="Reserved"></Flag>
+            <Flag bit="63" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <register name="cr1" description="Control register 1. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </register>
+    <Register name="cr2" description="Control Register 2. This control register contains the linear (virtual) address whcih triggered a page fault, available in the page fault's interrupt hander." type="Control Register" width="64 bits">
+    </Register>
+    <Register name="cr3" description="Control Register 3. This must be page aligned." type="Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="1" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="2" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="3" label="PWT if CR4.PCIDE = 0" description="Page-Level Write Through if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="4" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="5" label="PCD if CR4.PCIDE = 0" description="Page-Level Cache Disable if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="6" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="7" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="8" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="9" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="10" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="11" label="" description="Reserved if CR4.PCIDE = 0. PCID if CR4.PCIDE = 1"></Flag>
+            <Flag bit="12" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="13" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="14" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="15" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="16" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="17" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="18" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="19" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="20" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="21" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="22" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="23" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="24" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="25" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="26" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="27" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="28" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="29" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="30" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="31" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="32" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="33" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="34" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="35" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="36" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="37" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="38" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="39" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="40" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="41" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="42" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="43" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="44" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="45" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="46" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="47" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="48" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="49" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="50" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="51" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="52" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="53" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="54" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="55" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="56" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="57" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="58" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="59" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="60" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="61" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="62" label="" description="Physical Base Address of the PML4"></Flag>
+            <Flag bit="63" label="" description="Physical Base Address of the PML4"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr4" description="Control Register 4" type="Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="VME" description="Virtual 8086 Mode Extensions"></Flag>
+            <Flag bit="1" label="PVI" description="Protected-mode Virtual Interrupts"></Flag>
+            <Flag bit="2" label="TSD" description="Time Stamp Disable"></Flag>
+            <Flag bit="3" label="DE" description="Debugging Extensions"></Flag>
+            <Flag bit="4" label="PSE" description="Page Size Extension"></Flag>
+            <Flag bit="5" label="PAE" description="Physical Address Extension"></Flag>
+            <Flag bit="6" label="MCE" description="Machine Check Exception"></Flag>
+            <Flag bit="7" label="PGE" description="Page Global Enabled"></Flag>
+            <Flag bit="8" label="PCE" description="Performance-Monitoring Counter enable"></Flag>
+            <Flag bit="9" label="OSFXSR" description="Operating system support for FXSAVE and FXRSTOR operations"></Flag>
+            <Flag bit="10" label="OSXMMEXCPT" description="Operating System Support for Unmasked SIMD Floating-Point Exceptions"></Flag>
+            <Flag bit="11" label="UMIP" description="User-Mode Instruction Prevention (if set, #GP on SGDT, SIDT, SLDT, SMSW, and STR instructions when CPL>0)"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="VMXE" description="Virtual Machine Extensions Enable"></Flag>
+            <Flag bit="14" label="SMXE" description="Safer Mode Extensions Enable"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="FSGSBASE" description="Enables the instructions RDFSBASE, RDGSBASE, WRFSBASE, and WRGSBASE"></Flag>
+            <Flag bit="17" label="PCIDE" description="PCID Enable"></Flag>
+            <Flag bit="18" label="OSXSAVE" description="XSAVE and Processor Extended States Enable"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="SMEP" description="Supervisor Mode Execution Protection Enable"></Flag>
+            <Flag bit="21" label="SMAP" description="Supervisor Modde Access Prevention Enable"></Flag>
+            <Flag bit="22" label="PKE" description="Protection Key Enable"></Flag>
+            <Flag bit="23" label="CET" description="Control-flow Enforcement Technology"></Flag>
+            <Flag bit="24" label="PKS" description="Enable Protection Keys for Supervisor-Mode Pages"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="Reserved"></Flag>
+            <Flag bit="33" label="" description="Reserved"></Flag>
+            <Flag bit="34" label="" description="Reserved"></Flag>
+            <Flag bit="35" label="" description="Reserved"></Flag>
+            <Flag bit="36" label="" description="Reserved"></Flag>
+            <Flag bit="37" label="" description="Reserved"></Flag>
+            <Flag bit="38" label="" description="Reserved"></Flag>
+            <Flag bit="39" label="" description="Reserved"></Flag>
+            <Flag bit="40" label="" description="Reserved"></Flag>
+            <Flag bit="41" label="" description="Reserved"></Flag>
+            <Flag bit="42" label="" description="Reserved"></Flag>
+            <Flag bit="43" label="" description="Reserved"></Flag>
+            <Flag bit="44" label="" description="Reserved"></Flag>
+            <Flag bit="45" label="" description="Reserved"></Flag>
+            <Flag bit="46" label="" description="Reserved"></Flag>
+            <Flag bit="47" label="" description="Reserved"></Flag>
+            <Flag bit="48" label="" description="Reserved"></Flag>
+            <Flag bit="49" label="" description="Reserved"></Flag>
+            <Flag bit="50" label="" description="Reserved"></Flag>
+            <Flag bit="51" label="" description="Reserved"></Flag>
+            <Flag bit="52" label="" description="Reserved"></Flag>
+            <Flag bit="53" label="" description="Reserved"></Flag>
+            <Flag bit="54" label="" description="Reserved"></Flag>
+            <Flag bit="55" label="" description="Reserved"></Flag>
+            <Flag bit="56" label="" description="Reserved"></Flag>
+            <Flag bit="57" label="" description="Reserved"></Flag>
+            <Flag bit="58" label="" description="Reserved"></Flag>
+            <Flag bit="59" label="" description="Reserved"></Flag>
+            <Flag bit="60" label="" description="Reserved"></Flag>
+            <Flag bit="61" label="" description="Reserved"></Flag>
+            <Flag bit="62" label="" description="Reserved"></Flag>
+            <Flag bit="63" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr5" description="Control Register 5. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr6" description="Control Register 6. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr7" description="Control Register 7. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr8" description="Control Register 8. CR8 is used to prioritize external interrupts and is referred to as the task-priority register (TPR).
+
+The AMD64 architecture allows software to define up to 15 external interrupt-priority classes. Priority classes are numbered from 1 to 15, with priority-class 1 being the lowest and priority-class 15 the highest. CR8 uses the four low-order bits for specifying a task priority and the remaining 60 bits are reserved and must be written with zeros.
+
+System software can use the TPR register to temporarily block low-priority interrupts from interrupting a high-priority task. This is accomplished by loading TPR with a value corresponding to the highest-priority interrupt that is to be blocked. For example, loading TPR with a value of 9 (1001b) blocks all interrupts with a priority class of 9 or less, while allowing all interrupts with a priority class of 10 or more to be recognized. Loading TPR with 0 enables all external interrupts. Loading TPR with 15 (1111b) disables all external interrupts.
+
+The TPR is cleared to 0 on reset."
+        type="Control Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="" description="Priority"></Flag>
+            <Flag bit="1" label="" description="Priority"></Flag>
+            <Flag bit="2" label="" description="Priority"></Flag>
+            <Flag bit="3" label="" description="Priority"></Flag>
+            <Flag bit="4" label="" description="Reserved"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="" description="Reserved"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="" description="Reserved"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="Reserved"></Flag>
+            <Flag bit="33" label="" description="Reserved"></Flag>
+            <Flag bit="34" label="" description="Reserved"></Flag>
+            <Flag bit="35" label="" description="Reserved"></Flag>
+            <Flag bit="36" label="" description="Reserved"></Flag>
+            <Flag bit="37" label="" description="Reserved"></Flag>
+            <Flag bit="38" label="" description="Reserved"></Flag>
+            <Flag bit="39" label="" description="Reserved"></Flag>
+            <Flag bit="40" label="" description="Reserved"></Flag>
+            <Flag bit="41" label="" description="Reserved"></Flag>
+            <Flag bit="42" label="" description="Reserved"></Flag>
+            <Flag bit="43" label="" description="Reserved"></Flag>
+            <Flag bit="44" label="" description="Reserved"></Flag>
+            <Flag bit="45" label="" description="Reserved"></Flag>
+            <Flag bit="46" label="" description="Reserved"></Flag>
+            <Flag bit="47" label="" description="Reserved"></Flag>
+            <Flag bit="48" label="" description="Reserved"></Flag>
+            <Flag bit="49" label="" description="Reserved"></Flag>
+            <Flag bit="50" label="" description="Reserved"></Flag>
+            <Flag bit="51" label="" description="Reserved"></Flag>
+            <Flag bit="52" label="" description="Reserved"></Flag>
+            <Flag bit="53" label="" description="Reserved"></Flag>
+            <Flag bit="54" label="" description="Reserved"></Flag>
+            <Flag bit="55" label="" description="Reserved"></Flag>
+            <Flag bit="56" label="" description="Reserved"></Flag>
+            <Flag bit="57" label="" description="Reserved"></Flag>
+            <Flag bit="58" label="" description="Reserved"></Flag>
+            <Flag bit="59" label="" description="Reserved"></Flag>
+            <Flag bit="60" label="" description="Reserved"></Flag>
+            <Flag bit="61" label="" description="Reserved"></Flag>
+            <Flag bit="62" label="" description="Reserved"></Flag>
+            <Flag bit="63" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="cr9" description="Control Register 9. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr10" description="Control Register 10. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr11" description="Control Register 11. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr12" description="Control Register 12. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr13" description="Control Register 13. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr14" description="Control Register 14. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="cr15" description="Control Register 15. Reserved, CPU will throw a #ud exception when trying to access." type="Control Register">
+    </Register>
+    <Register name="ia32_efer" description="The Extended Feature Enable Register (EFER) is a model-specific register added in the AMD K6 processor, to allow enabling the SYSCALL/SYSRET instruction, and later for entering and exiting long mode. This register becomes architectural in AMD64 and has been adopted by Intel. Its MSR number is 0xC0000080." type="Machine State Register" width="64 bits">
+        <Flags>
+            <Flag bit="0" label="SCE" description="System Call Extensions"></Flag>
+            <Flag bit="1" label="" description="Reserved"></Flag>
+            <Flag bit="2" label="" description="Reserved"></Flag>
+            <Flag bit="3" label="" description="Reserved"></Flag>
+            <Flag bit="4" label="" description="Reserved"></Flag>
+            <Flag bit="5" label="" description="Reserved"></Flag>
+            <Flag bit="6" label="" description="Reserved"></Flag>
+            <Flag bit="7" label="" description="Reserved"></Flag>
+            <Flag bit="8" label="LME" description="Long Mode Enable"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="LMA" description="Long Mode Active"></Flag>
+            <Flag bit="11" label="NXE" description="No-Execute Enable"></Flag>
+            <Flag bit="12" label="SVME" description="Secure Virtual Machine Enable"></Flag>
+            <Flag bit="13" label="LMSLE" description="Long Mode Segment Limit Enable"></Flag>
+            <Flag bit="14" label="FFXSR" description="Fast FXSAVE/FXSTOR"></Flag>
+            <Flag bit="15" label="TCE" description="Translate Cache Extension"></Flag>
+            <Flag bit="16" label="" description="Reserved"></Flag>
+            <Flag bit="17" label="" description="Reserved"></Flag>
+            <Flag bit="18" label="" description="Reserved"></Flag>
+            <Flag bit="19" label="" description="Reserved"></Flag>
+            <Flag bit="20" label="" description="Reserved"></Flag>
+            <Flag bit="21" label="" description="Reserved"></Flag>
+            <Flag bit="22" label="" description="Reserved"></Flag>
+            <Flag bit="23" label="" description="Reserved"></Flag>
+            <Flag bit="24" label="" description="Reserved"></Flag>
+            <Flag bit="25" label="" description="Reserved"></Flag>
+            <Flag bit="26" label="" description="Reserved"></Flag>
+            <Flag bit="27" label="" description="Reserved"></Flag>
+            <Flag bit="28" label="" description="Reserved"></Flag>
+            <Flag bit="29" label="" description="Reserved"></Flag>
+            <Flag bit="30" label="" description="Reserved"></Flag>
+            <Flag bit="31" label="" description="Reserved"></Flag>
+            <Flag bit="32" label="" description="Reserved"></Flag>
+            <Flag bit="33" label="" description="Reserved"></Flag>
+            <Flag bit="34" label="" description="Reserved"></Flag>
+            <Flag bit="35" label="" description="Reserved"></Flag>
+            <Flag bit="36" label="" description="Reserved"></Flag>
+            <Flag bit="37" label="" description="Reserved"></Flag>
+            <Flag bit="38" label="" description="Reserved"></Flag>
+            <Flag bit="39" label="" description="Reserved"></Flag>
+            <Flag bit="40" label="" description="Reserved"></Flag>
+            <Flag bit="41" label="" description="Reserved"></Flag>
+            <Flag bit="42" label="" description="Reserved"></Flag>
+            <Flag bit="43" label="" description="Reserved"></Flag>
+            <Flag bit="44" label="" description="Reserved"></Flag>
+            <Flag bit="45" label="" description="Reserved"></Flag>
+            <Flag bit="46" label="" description="Reserved"></Flag>
+            <Flag bit="47" label="" description="Reserved"></Flag>
+            <Flag bit="48" label="" description="Reserved"></Flag>
+            <Flag bit="49" label="" description="Reserved"></Flag>
+            <Flag bit="50" label="" description="Reserved"></Flag>
+            <Flag bit="51" label="" description="Reserved"></Flag>
+            <Flag bit="52" label="" description="Reserved"></Flag>
+            <Flag bit="53" label="" description="Reserved"></Flag>
+            <Flag bit="54" label="" description="Reserved"></Flag>
+            <Flag bit="55" label="" description="Reserved"></Flag>
+            <Flag bit="56" label="" description="Reserved"></Flag>
+            <Flag bit="57" label="" description="Reserved"></Flag>
+            <Flag bit="58" label="" description="Reserved"></Flag>
+            <Flag bit="59" label="" description="Reserved"></Flag>
+            <Flag bit="60" label="" description="Reserved"></Flag>
+            <Flag bit="61" label="" description="Reserved"></Flag>
+            <Flag bit="62" label="" description="Reserved"></Flag>
+            <Flag bit="63" label="" description="Reserved"></Flag>
+        </Flags>
+    </Register>
+    <Register name="fs.base" description="MSR with the address 0xC0000100, contains the base address of the FS segment register. This is commonly used for thread-pointers in user code and CPU-local pointers in kernel code. Safe to contain anything, since use of a segment does not confer additional privileges to user code.
+
+In newer CPUs, this can also be written with the WRFSBASE instruction at any privilege level."
+        type="Machine State Register">
+    </Register>
+    <Register name="gs.base" description="MSR with the address 0xC0000101, contains the base address of the GS segment register. This is commonly used for thread-pointers in user code and CPU-local pointers in kernel code. Safe to contain anything, since use of a segment does not confer additional privileges to user code.
+
+In newer CPUs, this can also be written with the WRGSBASE instruction at any privilege level."
+        type="Machine State Register">
+    </Register>
+    <Register name="kernelgsbase" description="MSR with the address 0xC0000102. Is basically a buffer that gets exchanged with GS.base after a swapgs instruction. Usually used to separate kernel and other use of the GS register."
+        type="Machine State Register">
+    </Register>
+    <Register name="dr0" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register">
+    </Register>
+    <Register name="dr1" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register">
+    </Register>
+    <Register name="dr2" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register">
+    </Register>
+    <Register name="dr3" description="Can contain linear address of a breakpoint. If paging is enabled, it is translated to a physical address" type="Debug Register">
+    </Register>
+    <Register name="dr6" description="Permits the debugger to determine which debug conditions have occurred. When an enabled debug exception is triggered, low order bits 0-3 are set before entering debug exception handler.">
+    </Register>
+    <Register name="dr7" description="A local breakpoint bit deactivates on hardware task switches, while a global does not. Condition 00b means execution break, 01b means a write watchpoint, and 11b means a R/W watchpoint. 10b is reserved for I/O R/W (unsupported)" type="Debug Register" width="32 bits">
+        <Flags>
+            <Flag bit="0" label="" description="Local DR0 breakpoint"></Flag>
+            <Flag bit="1" label="" description="Global DR0 breakpoint"></Flag>
+            <Flag bit="2" label="" description="Local DR1 breakpoint"></Flag>
+            <Flag bit="3" label="" description="Global DR1 breakpoint"></Flag>
+            <Flag bit="4" label="" description="Local DR2 breakpoint"></Flag>
+            <Flag bit="5" label="" description="Global DR2 breakpoint"></Flag>
+            <Flag bit="6" label="" description="Local DR3 breakpoint"></Flag>
+            <Flag bit="7" label="" description="Global DR3 breakpoint"></Flag>
+            <Flag bit="8" label="" description="Reserved"></Flag>
+            <Flag bit="9" label="" description="Reserved"></Flag>
+            <Flag bit="10" label="" description="Reserved"></Flag>
+            <Flag bit="11" label="" description="Reserved"></Flag>
+            <Flag bit="12" label="" description="Reserved"></Flag>
+            <Flag bit="13" label="" description="Reserved"></Flag>
+            <Flag bit="14" label="" description="Reserved"></Flag>
+            <Flag bit="15" label="" description="Reserved"></Flag>
+            <Flag bit="16" label="" description="Condition for DR0"></Flag>
+            <Flag bit="17" label="" description="Condition for DR0"></Flag>
+            <Flag bit="18" label="" description="Size of DR0 breakpoint"></Flag>
+            <Flag bit="19" label="" description="Size of DR0 breakpoint"></Flag>
+            <Flag bit="20" label="" description="Condition for DR1"></Flag>
+            <Flag bit="21" label="" description="Condition for DR1"></Flag>
+            <Flag bit="22" label="" description="Size of DR1 breakpoint"></Flag>
+            <Flag bit="23" label="" description="Size of DR1 breakpoint"></Flag>
+            <Flag bit="24" label="" description="Condition for DR2"></Flag>
+            <Flag bit="25" label="" description="Condition for DR2"></Flag>
+            <Flag bit="26" label="" description="Size of DR2 breakpoint"></Flag>
+            <Flag bit="27" label="" description="Size of DR2 breakpoint"></Flag>
+            <Flag bit="28" label="" description="Condition for DR3"></Flag>
+            <Flag bit="29" label="" description="Condition for DR3"></Flag>
+            <Flag bit="30" label="" description="Size of DR3 breakpoint"></Flag>
+            <Flag bit="31" label="" description="Size of DR3 breakpoint"></Flag>
+        </Flags>
+    </Register>
+    <Register name="tr3" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr4" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr5" description="Undocumented" type="Test Register">
+    </Register>
+    <Register name="tr6" description="Test command register" type="Test Register">
+    </Register>
+    <Register name="tr7" description="Test data register" type="Test Register">
+    </Register>
+    <Register name="gdtr" description="" type="Protected Mode Register" width="80 bits">
+        <Flags>
+            <Flag bit="0" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="1" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="2" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="3" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="4" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="5" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="6" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="7" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="8" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="9" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="10" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="11" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="12" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="13" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="14" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="15" label="Limit" description="Size of GDT"></Flag>
+            <Flag bit="16" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="17" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="18" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="19" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="20" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="21" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="22" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="23" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="24" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="25" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="26" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="27" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="28" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="79" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="30" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="31" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="32" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="33" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="34" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="35" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="36" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="37" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="38" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="39" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="40" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="41" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="42" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="43" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="44" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="45" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="46" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="47" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="48" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="49" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="50" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="51" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="52" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="53" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="54" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="55" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="56" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="57" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="58" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="59" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="60" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="61" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="62" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="63" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="64" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="65" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="66" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="67" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="68" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="69" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="70" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="71" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="72" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="73" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="74" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="75" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="76" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="77" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="78" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="79" label="Base" description="Starting address of GDR (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+        </Flags>
+    </Register>
+    <Register name="ldtr" description="Stores the segment selector of the LDT" type="Protected Mode Register">
+    </Register>
+    <Register name="tr" description="Stores the segment selector of the TSS" type="Protected Mode Register">
+    </Register>
+    <Register name="idtr" description="" type="Protected Mode Register" width="80 bits">
+        <Flags>
+            <Flag bit="0" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="1" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="2" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="3" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="4" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="5" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="6" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="7" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="8" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="9" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="10" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="11" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="12" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="13" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="14" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="15" label="Limit" description="Size of IDT"></Flag>
+            <Flag bit="16" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="17" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="18" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="19" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="20" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="21" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="22" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="23" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="24" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="25" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="26" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="27" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="28" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="79" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="30" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="31" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="32" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="33" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="34" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="35" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="36" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="37" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="38" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="39" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="40" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="41" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="42" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="43" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="44" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="45" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="46" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="47" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="48" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="49" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="50" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="51" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="52" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="53" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="54" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="55" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="56" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="57" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="58" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="59" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="60" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="61" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="62" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="63" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="64" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="65" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="66" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="67" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="68" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="69" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="70" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="71" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="72" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="73" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="74" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="75" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="76" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="77" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="78" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+            <Flag bit="79" label="Base" description="Starting address of IDT (Bits 16-47 if 32 bit operand, bits 16-79 if 64 bit operand)"></Flag>
+        </Flags>
+    </Register>
+    <Register name="xmm0" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm1" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm2" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm3" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm4" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm5" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm6" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm7" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm8" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm9" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm10" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm11" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm12" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm13" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm14" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm15" description="A SIMD register. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm16" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm17" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm18" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm19" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm20" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm21" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm22" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm23" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm24" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm25" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm26" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm27" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm28" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm29" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm30" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="xmm31" description="A SIMD register available when AVX-512 is supported. Under SSE, this register can be used to store four 32-bit single-precision floating point numbers. SSE2 would later expand its usage to also allow two 64-bit double-precision floating point numbers, two 64-bit integers, four 32-bit integers, eight 16-bit short integers, or sixteen 8-bit bytes or characters."
+    type="SIMD Register" width="128 bits">
+    </Register>
+    <Register name="ymm0" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm1" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm2" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm3" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm4" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm5" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm6" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm7" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm8" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm9" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm10" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm11" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm12" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm13" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm14" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm15" description="A SIMD register. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm16" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm17" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm18" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm19" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm20" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm21" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm22" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm23" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm24" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm25" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm26" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm27" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm28" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm29" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm30" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="ymm31" description="A SIMD register available when AVX-512 is supported. This register can be used to store four 64-bit double-precision floating point numbers, or eight 32-bit single precision floating point numbers. The lower half maps onto the corresponding XMM register."
+    type="SIMD Register" width="256 bits">
+    </Register>
+    <Register name="zmm0" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm1" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm2" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm3" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm4" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm5" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm6" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm7" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm8" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm9" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm10" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm11" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm12" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm13" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm14" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm15" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm16" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm17" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm18" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm19" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm20" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm21" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm22" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm23" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm24" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm25" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm26" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm27" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm28" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm29" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm30" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
+    </Register>
+    <Register name="zmm31" description="A SIMD register. The lower half maps onto the corresponding YMM register."
+    type="SIMD Register" width="512 bits">
     </Register>
 </InstructionSet>

--- a/samples/gas.s
+++ b/samples/gas.s
@@ -33,7 +33,7 @@ main:
 	movq	%rax, %rdx
 	movzbl	-1(%rbp), %eax
 	andl	$15, %eax
-	movl	%eax, %esi
+	movl	%RAX, %esi
 	movq	%rdx, %rdi
 	call	_ZNSolsEi@PLT
 	movq	%rax, %rdx

--- a/samples/gas.s
+++ b/samples/gas.s
@@ -33,7 +33,7 @@ main:
 	movq	%rax, %rdx
 	movzbl	-1(%rbp), %eax
 	andl	$15, %eax
-	movl	%RAX, %esi
+	movl	%eax, %esi
 	movq	%rdx, %rdi
 	call	_ZNSolsEi@PLT
 	movq	%rax, %rdx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,7 @@ pub mod x86_parser;
 
 pub use lsp::*;
 pub use types::*;
-pub use x86_parser::{populate_instructions, populate_name_to_instruction_map, populate_registers, populate_name_to_register_map};
+pub use x86_parser::{
+    populate_instructions, populate_name_to_instruction_map, populate_name_to_register_map,
+    populate_registers,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ pub mod x86_parser;
 
 pub use lsp::*;
 pub use types::*;
-pub use x86_parser::{populate_instructions, populate_name_to_instruction_map};
+pub use x86_parser::{populate_instructions, populate_name_to_instruction_map, populate_registers, populate_name_to_register_map};

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -128,7 +128,7 @@ pub fn get_target_config(params: &InitializeParams) -> TargetConfig {
     TargetConfig::default()
 }
 
-pub fn filter_targets(instr: &Instruction, config: &TargetConfig) -> Instruction {
+pub fn instr_filter_targets(instr: &Instruction, config: &TargetConfig) -> Instruction {
     let mut instr = instr.clone();
 
     let forms = instr

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,107 +1,24 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 use strum_macros::{AsRefStr, Display, EnumString};
-
-// Register ---------------------------------------------------------------------------------------
-#[derive(Debug, Clone)]
-pub struct Register {
-    pub name: String,
-    pub description: String,
-    pub reg_type: Option<RegisterType>,
-    pub location: Option<RegisterLocation>,
-    pub bit_info: Vec<RegisterBitInfo>,
-    pub url: Option<String>,
-    pub arch: Option<Arch>,
-}
-
-impl Default for Register {
-    fn default() -> Self {
-        let name = String::new();
-        let description = String::new();
-        let reg_type = None;
-        let location = None;
-        let bit_info = vec![];
-        let url = None;
-        let arch = None;
-
-        Self {
-            name,
-            description,
-            reg_type,
-            location,
-            bit_info,
-            url,
-            arch,
-        }
-    }
-}
-
-impl std::fmt::Display for Register {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // basic fields
-        let header: String;
-        if let Some(arch) = &self.arch {
-            header = format!("{} [{}]", &self.name, arch.as_ref());
-        } else {
-            header = self.name.clone();
-        }
-
-        let mut v: Vec<String> = vec![header.clone(), self.description.clone(), String::from("\n")];
-
-        // Register Type
-        let reg_type_str = if let Some(reg_type_) = self.reg_type {
-            reg_type_.to_string()
-        } else {
-            String::new()
-        };
-        if !reg_type_str.is_empty() {
-            v.push(reg_type_str);
-        }
-
-        // Register Location
-        let reg_loc_str = if let Some(location_) = self.location {
-            location_.to_string()
-        } else {
-            String::new()
-        };
-        if !reg_loc_str.is_empty() {
-            v.push(reg_loc_str);
-        }
-
-        // Bit Meanings
-        for (i, bit) in self.bit_info.iter().enumerate() {
-            v.push(format!("{:2}: {} - {}", i, bit.label, bit.description));
-        }
-
-        // url
-        let more_info: String;
-        match &self.url {
-            None => {}
-            Some(url_) => {
-                more_info = format!("\nMore info: {}", url_);
-                v.push(more_info.clone());
-            }
-        }
-
-        let s = v.join("\n");
-        write!(f, "{}", s)?;
-        Ok(())
-    }
-}
 
 // Instruction ------------------------------------------------------------------------------------
 #[derive(Debug, Clone)]
 pub struct Instruction {
     pub name: String,
+    pub alt_names: Vec<String>,
     pub summary: String,
     pub forms: Vec<InstructionForm>,
     pub url: Option<String>,
     pub arch: Option<Arch>,
 }
 
+impl Hoverable for &Instruction {}
+
 impl Default for Instruction {
     fn default() -> Self {
         let name = String::new();
+        let alt_names = vec![];
         let summary = String::new();
         let forms = vec![];
         let url = None;
@@ -109,6 +26,7 @@ impl Default for Instruction {
 
         Self {
             name,
+            alt_names,
             summary,
             forms,
             url,
@@ -127,7 +45,7 @@ impl std::fmt::Display for Instruction {
             header = self.name.clone();
         }
 
-        let mut v: Vec<&'_ str> = vec![&header, &self.summary, "\n", "## Forms", "\n"];
+        let mut v: Vec<&str> = vec![&header, &self.summary, "\n", "## Forms", "\n"];
 
         // instruction forms
         let instruction_form_strs: Vec<String> =
@@ -162,6 +80,10 @@ impl<'own> Instruction {
     pub fn get_associated_names(&'own self) -> Vec<&'own str> {
         let mut names = Vec::<&'own str>::new();
         names.push(&self.name);
+
+        for name in &self.alt_names {
+            names.push(name);
+        }
 
         for f in &self.forms {
             for name in [&f.gas_name, &f.go_name].iter().copied().flatten() {
@@ -244,12 +166,127 @@ impl std::fmt::Display for InstructionForm {
     }
 }
 
+// Register ---------------------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+pub struct Register {
+    pub name: String,
+    pub alt_names: Vec<String>,
+    pub description: Option<String>,
+    pub reg_type: Option<RegisterType>,
+    pub width: Option<RegisterWidth>,
+    pub flag_info: Vec<RegisterBitInfo>,
+    pub arch: Option<Arch>,
+    pub url: Option<String>,
+}
+
+impl Hoverable for &Register {}
+
+impl Default for Register {
+    fn default() -> Self {
+        let name = String::new();
+        let alt_names = vec![];
+        let description = None;
+        let reg_type = None;
+        let width = None;
+        let flag_info = vec![];
+        let arch = None;
+        let url = None;
+
+        Self {
+            name,
+            alt_names,
+            description,
+            reg_type,
+            width,
+            flag_info,
+            arch,
+            url,
+        }
+    }
+}
+
+impl std::fmt::Display for Register {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // basic fields
+        let header: String;
+        if let Some(arch) = &self.arch {
+            header = format!("{} [{}]", &self.name.to_uppercase(), arch.as_ref());
+        } else {
+            header = self.name.to_uppercase();
+        }
+
+        let mut v: Vec<String> = if let Some(description_) = &self.description {
+            vec![header, description_.clone(), String::from("\n")]
+        } else {
+            vec![header, String::from("\n")]
+        };
+
+        // Register Type
+        if let Some(reg_type_) = &self.reg_type {
+            let reg_type = format!("Type: {}", reg_type_);
+            v.push(reg_type);
+        }
+
+        // Register Width
+        if let Some(reg_width_) = self.width {
+            let reg_width = format!("Width: {}", reg_width_);
+            v.push(reg_width);
+        }
+
+        // Bit-mask flag meanings if applicable
+        if !self.flag_info.is_empty() {
+            let flag_heading = String::from("\n## Flags:");
+            v.push(flag_heading);
+
+            let flags: Vec<String> = self
+                .flag_info
+                .iter()
+                .map(|flag| format!("{}", flag))
+                .collect();
+            for flag in flags.iter() {
+                v.push(flag.clone());
+            }
+        }
+
+        // TODO: URL support
+        if let Some(url_) = &self.url {
+            let more_info = format!("\nMore info: {}", url_);
+            v.push(more_info);
+        }
+
+        let s = v.join("\n");
+        write!(f, "{}", s)?;
+        Ok(())
+    }
+}
+
+impl<'own> Register {
+    /// Add a new bit flag entry at the current instruction
+    pub fn push_flag(&mut self, flag: RegisterBitInfo) {
+        self.flag_info.push(flag);
+    }
+
+    /// get the names of all the associated registers
+    pub fn get_associated_names(&'own self) -> Vec<&'own str> {
+        let mut names = Vec::<&'own str>::new();
+        names.push(&self.name);
+
+        for name in &self.alt_names {
+            names.push(name);
+        }
+
+        names
+    }
+}
+
 // helper structs, types and functions ------------------------------------------------------------
 pub type NameToInstructionMap<'instruction> =
     HashMap<(Arch, &'instruction str), &'instruction Instruction>;
 
-pub type NameToRegisterMap<'register> = 
-    HashMap<(Arch, &'register str), &'register Register>;
+pub type NameToRegisterMap<'register> = HashMap<(Arch, &'register str), &'register Register>;
+
+// Define a trait for types we display on Hover Requests so we can avoid some duplicate code
+pub trait Hoverable: Display + Clone + Copy {}
 
 #[derive(Debug, Clone, EnumString, AsRefStr)]
 pub enum XMMMode {
@@ -277,10 +314,12 @@ pub enum RegisterType {
     Pointer,
     #[strum(serialize = "Segment Register")]
     Segment,
-    #[strum(serialize = "RFLAGS Register")]
-    RFLAGS,
+    #[strum(serialize = "Flag Register")]
+    Flag,
     #[strum(serialize = "Control Register")]
     Control,
+    #[strum(serialize = "Extended Control Register")]
+    ExtendedControl,
     #[strum(serialize = "Machine State Register")]
     MSR,
     #[strum(serialize = "Debug Register")]
@@ -292,23 +331,55 @@ pub enum RegisterType {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, EnumString, AsRefStr, Display)]
-pub enum RegisterLocation {
-    #[strum(serialize = "64-bit")]
+pub enum RegisterWidth {
+    #[strum(serialize = "512 bits")]
+    Bits512,
+    #[strum(serialize = "256 bits")]
+    Bits256,
+    #[strum(serialize = "128 bits")]
+    Bits128,
+    #[strum(serialize = "32(64) bits")]
+    Bits32Or64,
+    #[strum(serialize = "64 bits")]
     Bits64,
-    #[strum(serialize = "32-bit")]
+    #[strum(serialize = "48 bits")]
+    Bits48,
+    #[strum(serialize = "32 bits")]
     Bits32,
-    #[strum(serialize = "16-bit")]
+    #[strum(serialize = "16 bits")]
     Bits16,
     #[strum(serialize = "8 high bits of lower 16 bits")]
     Upper8Lower16,
-    #[strum(serialize = "8-bit")]
+    #[strum(serialize = "8 lower bits")]
     Lower8Lower16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
 pub struct RegisterBitInfo {
-    label: String,
-    description: String,
+    pub bit: u32,
+    pub label: String,
+    pub description: String,
+    pub pae: String,
+    pub long_mode: String,
+}
+
+impl std::fmt::Display for RegisterBitInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = if self.label.is_empty() {
+            format!("{:2}: {}", self.bit, self.description)
+        } else {
+            format!("{:2}: {} - {}", self.bit, self.label, self.description)
+        };
+        if !self.pae.is_empty() {
+            s += &format!(", PAE: {}", self.pae);
+        }
+        if !self.long_mode.is_empty() {
+            s += &format!(", Long Mode: {}", self.long_mode);
+        }
+
+        write!(f, "{}", s)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -21,6 +21,31 @@ use std::str::FromStr;
 ///
 /// Current function assumes that the XML file is already read and that it's been given a reference
 /// to its contents (`&str`).
+pub fn populate_registers(xml_contents: &str) -> anyhow::Result<Vec<Register>> {
+    // initialise the instruction set
+    let mut registers_map = HashMap::<String, Register>::new();
+
+    // iterate through the XML --------------------------------------------------------------------
+    let mut reader = Reader::from_str(xml_contents);
+    reader.trim_text(true);
+
+    // ref to the instruction that's currently under construction
+    let mut curr_instruction = Instruction::default();
+    let mut curr_instruction_form = InstructionForm::default();
+
+    debug!("Parsing XML contents...");
+    loop {
+        break;
+    }
+
+    Ok(registers_map.into_values().collect())
+}
+
+/// Parse the provided XML contents and return a vector of all the instrucitons based on that.
+/// If parsing fails, the appropriate error will be returned instead.
+///
+/// Current function assumes that the XML file is already read and that it's been given a reference
+/// to its contents (`&str`).
 pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instruction>> {
     // initialise the instruction set
     let mut instructions_map = HashMap::<String, Instruction>::new();
@@ -283,6 +308,16 @@ mod tests {
         }
 
         mock.assert();
+    }
+}
+
+pub fn populate_name_to_register_map<'register>(
+    arch: Arch,
+    registers: &'register Vec<Register>,
+    names_to_registers: &mut NameToRegisterMap<'register>,
+) {
+    for register in registers {
+        names_to_registers.insert((arch, &register.name), register);
     }
 }
 


### PR DESCRIPTION
First pass on adding hover support for CPU registers. Hover info includes  type, width, and a brief description. If the register's bits are used as flags, the meaning of each bit is also displayed.

I wasn't able to find a resource analogous to the opcode xml files that this repo has for the instruction sets, so I created my own (``registers/x86.xml`` and ``registers/x86_64.xml``) using https://wiki.osdev.org/CPU_Registers_x86 , https://wiki.osdev.org/CPU_Registers_x86-64 , and a few wikipedia pages for the SIMD registers.

I did my best to follow the general flow/ style already established for the instruction sets, which made implementing this very straightforward. Filtering out registers from certain architectures via the ``.asm-lsp.toml`` file works just as with the instructions. I'd like to add the register info to the ``.xml`` files in a more automated way, but I think this implementation functions well as a placeholder at least (example screenshots below).

![image](https://github.com/bergercookie/asm-lsp/assets/87077023/f967ae16-da1a-4f22-b6b5-4601346b42ab)
![image](https://github.com/bergercookie/asm-lsp/assets/87077023/b05f1270-507e-4175-b4aa-f24948604951)

Certain flag registers (whether directly accessible or not) have each bit marked with its corresponding meaning. The screenshot below shows hover info for ``%cr0`` (Control Register 0)

![image](https://github.com/bergercookie/asm-lsp/assets/87077023/bd9548c5-2391-43af-bb53-5c9970e97c4d)

Sorry about this PR being a bit on the long side of things. I'm perfectly happy to spend some more time gathering additional info for the register ``.xml`` files, or removing some of the information that's there if it's extraneous. I kind of went out on my own here so if this isn't something you want the project to support that's also completely understandable. Regardless I had a lot of fun throwing this together. In addition, I built off of the changes in this PR to add autocomplete abilities for instructions and registers (for GAS, at least) in another branch that I'm currently cleaning up/ testing (very excited about this).

EDIT: I looked back at this and realized there was a some repeated logic/ code between ``Register`` and ``Instruction``. I tried to simplify things a bit by adding a ``Hoverable`` trait for them to implement, but if you think this is a bad design decision I'm  completely fine reverting.