### PR TITLE
fix: completion filter bug

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -166,7 +166,7 @@ pub fn get_comp_resp(
         if ctx.trigger_kind == CompletionTriggerKind::TRIGGER_CHARACTER {
             return Some(CompletionList {
                 is_incomplete: true,
-                items: reg_comps.to_owned(),
+                items: filtered_comp_list(reg_comps),
             });
         }
     }


### PR DESCRIPTION
While testing another feature I found a bug in which I forgot to filter the completion response items in the case where the corresponding completion request was triggered by a '%' character. 