### PR TITLE
Incremental parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "home",
  "log",
  "lsp-server",
+ "lsp-textdocument",
  "lsp-types",
  "mockito",
  "once_cell",
@@ -629,6 +630,16 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-textdocument"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62dcaf776a57a63c3baafa3ab0ae25943049865c862980522a5112b1fd849503"
+dependencies = [
+ "lsp-types",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,6 @@ mockito = "1.2.0"
 tree-sitter = "0.20.10"
 tree-sitter-asm = "0.1.0"
 once_cell = "1.18.0"
+lsp-textdocument = "0.3.2"
 
 # [dev-dependencies]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,6 +6,9 @@ use lsp_types::request::{Completion, DocumentSymbolRequest, HoverRequest};
 use lsp_types::*;
 
 use crate::lsp::{get_document_symbols, get_target_config, instr_filter_targets};
+use lsp_textdocument::FullTextDocument;
+
+use lsp_textdocument::FullTextDocument;
 
 use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use serde_json::json;
@@ -23,6 +26,9 @@ pub fn main() -> anyhow::Result<()> {
     // Create the transport
     let (connection, io_threads) = Connection::stdio();
 
+    // specify UTF-16 encoding for compatibility with lsp-textdocument
+    let position_encoding = Some(PositionEncodingKind::UTF16);
+
     // Run the server and wait for the two threads to end (typically by trigger LSP Exit event).
     let hover_provider = Some(HoverProviderCapability::Simple(true));
 
@@ -34,9 +40,12 @@ pub fn main() -> anyhow::Result<()> {
         ..Default::default()
     });
 
-    let text_document_sync = Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL));
+    let text_document_sync = Some(TextDocumentSyncCapability::Kind(
+        TextDocumentSyncKind::INCREMENTAL,
+    ));
 
     let capabilities = ServerCapabilities {
+        position_encoding,
         hover_provider,
         completion_provider,
         text_document_sync,
@@ -153,16 +162,18 @@ pub fn main() -> anyhow::Result<()> {
     populate_name_to_register_map(Arch::X86, &x86_registers, &mut names_to_registers);
     populate_name_to_register_map(Arch::X86_64, &x86_64_registers, &mut names_to_registers);
 
-    let instr_comps = get_completes(&names_to_instructions, Some(CompletionItemKind::OPERATOR));
-    let reg_comps = get_completes(&names_to_registers, Some(CompletionItemKind::VARIABLE));
+    let instr_completion_items =
+        get_completes(&names_to_instructions, Some(CompletionItemKind::OPERATOR));
+    let reg_completion_items =
+        get_completes(&names_to_registers, Some(CompletionItemKind::VARIABLE));
 
     main_loop(
         &connection,
         initialization_params,
         &names_to_instructions,
         &names_to_registers,
-        &instr_comps,
-        &reg_comps,
+        &instr_completion_items,
+        &reg_completion_items,
     )?;
     io_threads.join()?;
 
@@ -176,16 +187,13 @@ fn main_loop(
     params: serde_json::Value,
     names_to_instructions: &NameToInstructionMap,
     names_to_registers: &NameToRegisterMap,
-    instruction_completes: &[CompletionItem],
-    register_completes: &[CompletionItem],
+    instruction_completion_items: &[CompletionItem],
+    register_completion_items: &[CompletionItem],
 ) -> anyhow::Result<()> {
     let _params: InitializeParams = serde_json::from_value(params).unwrap();
-
-    let mut doc_open_params;
-    let mut doc_change_params;
-    let curr_doc = String::new();
-    let mut curr_doc = &curr_doc;
+    let mut curr_doc: Option<FullTextDocument> = None;
     let mut parser = tree_sitter::Parser::new();
+    let mut tree: Option<tree_sitter::Tree> = None;
     parser.set_logger(Some(Box::new(tree_sitter_logger)));
     parser.set_language(tree_sitter_asm::language())?;
 
@@ -240,33 +248,39 @@ fn main_loop(
                     }
                 } else if let Ok((id, params)) = cast_req::<Completion>(req.clone()) {
                     // CompletionRequest ---------------------------------------------------------------
+                    let res = Response {
+                        id: id.clone(),
+                        result: Some(json!("")),
+                        error: None,
+                    };
                     // get suggestions ------------------------------------------------------
-                    let comp_res = get_comp_resp(
-                        curr_doc,
-                        &mut parser,
-                        &params,
-                        instruction_completes,
-                        register_completes,
-                    );
-                    match comp_res {
-                        Some(_) => {
-                            let result = serde_json::to_value(&comp_res).unwrap();
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result))?;
+                    if let Some(ref doc) = curr_doc {
+                        let comp_res = get_comp_resp(
+                            doc.get_content(None),
+                            &mut parser,
+                            &mut tree,
+                            &params,
+                            instruction_completion_items,
+                            register_completion_items,
+                        );
+                        match comp_res {
+                            Some(_) => {
+                                let result = serde_json::to_value(&comp_res).unwrap();
+                                let result = Response {
+                                    id: id.clone(),
+                                    result: Some(result),
+                                    error: None,
+                                };
+                                connection.sender.send(Message::Response(result))?;
+                            }
+                            None => {
+                                // don't know what to suggest
+                                connection.sender.send(Message::Response(res.clone()))?;
+                            }
                         }
-                        None => {
-                            // don't know what to suggest
-                            let res = Response {
-                                id: id.clone(),
-                                result: Some(json!("")),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(res.clone()))?;
-                        }
+                    } else {
+                        // don't know what to suggest
+                        connection.sender.send(Message::Response(res.clone()))?;
                     }
                 } else if let Ok((id, params)) = cast_req::<DocumentSymbolRequest>(req.clone()) {
                     let symbols = get_document_symbols(curr_doc, &mut parser, &params);
@@ -297,12 +311,30 @@ fn main_loop(
             }
             Message::Notification(notif) => {
                 if let Ok(params) = cast_notif::<DidOpenTextDocument>(notif.clone()) {
-                    // move the notification's params into this variable so we can avoid cloning the document contents
-                    doc_open_params = params;
-                    curr_doc = &doc_open_params.text_document.text;
+                    curr_doc = Some(FullTextDocument::new(
+                        params.text_document.language_id.clone(),
+                        params.text_document.version,
+                        params.text_document.text.clone(),
+                    ));
+                    tree = parser.parse(params.text_document.text, None);
                 } else if let Ok(params) = cast_notif::<DidChangeTextDocument>(notif.clone()) {
-                    doc_change_params = params;
-                    curr_doc = &doc_change_params.content_changes.last().unwrap().text;
+                    if let Some(ref mut doc) = curr_doc {
+                        // Sync our in-memory copy of the current buffer
+                        doc.update(&params.content_changes, params.text_document.version);
+                        // Update the TS tree
+                        if let Some(ref mut curr_tree) = tree {
+                            for change in params.content_changes.iter() {
+                                match text_doc_change_to_ts_edit(change, doc) {
+                                    Ok(edit) => {
+                                        curr_tree.edit(&edit);
+                                    }
+                                    Err(e) => {
+                                        error!("Bad edit info, failed to edit tree - Error: {e}");
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
             Message::Response(_resp) => {}

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,12 +1,14 @@
 use crate::types::Column;
 use crate::{Arch, Completable, Hoverable, Instruction, TargetConfig};
 use log::{error, info, log, log_enabled};
+use lsp_textdocument::FullTextDocument;
 use lsp_types::*;
 use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufRead;
 use std::path::PathBuf;
+use tree_sitter::{InputEdit, Parser, Tree};
 
 /// Find the start and end indices of a word inside the given line
 /// Borrowed from RLS
@@ -67,6 +69,38 @@ pub fn tree_sitter_logger(log_type: tree_sitter::LogType, message: &str) {
     if log_enabled!(log_level) {
         log!(log_level, "{}", message);
     }
+}
+
+/// Convert an `lsp_types::TextDocumentContentChangeEvent` to a `tree_sitter::InputEdit`
+pub fn text_doc_change_to_ts_edit(
+    change: &TextDocumentContentChangeEvent,
+    doc: &FullTextDocument,
+) -> Result<InputEdit, &'static str> {
+    let range = change.range.ok_or("Invalid edit range")?;
+    let start = range.start;
+    let end = range.end;
+
+    let start_byte = doc.offset_at(start) as usize;
+    let new_end_byte = start_byte + change.text.len();
+    let new_end_pos = doc.position_at(new_end_byte as u32);
+
+    Ok(tree_sitter::InputEdit {
+        start_byte,
+        old_end_byte: doc.offset_at(end) as usize,
+        new_end_byte,
+        start_position: tree_sitter::Point {
+            row: start.line as usize,
+            column: start.character as usize,
+        },
+        old_end_position: tree_sitter::Point {
+            row: end.line as usize,
+            column: end.character as usize,
+        },
+        new_end_position: tree_sitter::Point {
+            row: new_end_pos.line as usize,
+            column: new_end_pos.character as usize,
+        },
+    })
 }
 
 /// Given a NameTo_SomeItem_ map, returns a `Vec<CompletionItem>` for the items
@@ -152,7 +186,8 @@ macro_rules! cursor_matches {
 
 pub fn get_comp_resp(
     curr_doc: &str,
-    parser: &mut tree_sitter::Parser,
+    parser: &mut Parser,
+    curr_tree: &mut Option<Tree>,
     params: &CompletionParams,
     instr_comps: &[CompletionItem],
     reg_comps: &[CompletionItem],
@@ -172,9 +207,7 @@ pub fn get_comp_resp(
     }
 
     // TODO: filter register completions by width allowed by corresponding instruction
-    // TODO: Would like to do incremental parsing but don't see a straightforward
-    // way to map the LSP's edit info the the format/ info tree-sitter is expecting...
-    let curr_tree = parser.parse(curr_doc, None);
+    *curr_tree = parser.parse(curr_doc, curr_tree.as_ref());
     if let Some(tree) = curr_tree {
         let mut cursor = tree_sitter::QueryCursor::new();
         cursor.set_point_range(std::ops::Range {


### PR DESCRIPTION
I found a [crate](https://crates.io/crates/lsp-textdocument) that takes care of all the messy translations needed to take advantage of tree-sitter's incremental parsing. Edit information is now communicated incrementally to the server. Edits are applied to the in memory copy of the buffer and the tree-sitter tree eagerly, but the tree re-parsed (incrementally!) in a lazy fashion whenever a completion request is received.

As far as I can tell, this is working at parity with the less-efficient (but simpler) "full-text" syncing method, but I think a second set of eyes testing could help.

Closes #31 