### PR TITLE
feat: demangle on hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "asm-lsp"
 version = "0.6.0"
 dependencies = [
@@ -68,6 +74,8 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "symbolic",
+ "symbolic-demangle",
  "toml",
  "tree-sitter",
  "tree-sitter-asm",
@@ -111,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,10 +137,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "brownstone"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -189,6 +218,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +252,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -226,6 +283,30 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "dmsort"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
+
+[[package]]
+name = "elementtree"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3efd4742acf458718a6456e0adf0b4d734d6b783e452bbf1ac36bf31f4085cb3"
+dependencies = [
+ "string_cache",
+]
+
+[[package]]
+name = "elsa"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -254,10 +335,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flexi_logger"
@@ -410,12 +513,27 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "h2"
@@ -568,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +699,15 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -601,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
+
+[[package]]
 name = "js-sys"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +753,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -690,16 +835,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memmap2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -741,6 +907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "msvc-demangler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +931,35 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -875,10 +1079,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
+dependencies = [
+ "fallible-iterator 0.2.0",
+ "scroll",
+ "uuid",
+]
+
+[[package]]
+name = "pdb-addr2line"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e89a9f2f40b2389ba6da0814c8044bf942bece03dffa1514f84e3b525f4f9a"
+dependencies = [
+ "bitflags 1.3.2",
+ "elsa",
+ "maybe-owned",
+ "pdb",
+ "range-collections",
+ "thiserror",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -899,10 +1137,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -959,6 +1209,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "range-collections"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fdfd79629e2b44a1d34b4d227957174cb858e6b86ee45fad114edbcfc903ab"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "smallvec",
 ]
 
 [[package]]
@@ -1095,6 +1356,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1397,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
@@ -1196,6 +1483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1524,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1560,90 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "symbolic"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec4f53c56d7ee8809c2322925d362e193bcc7bbe7e777a3304b34ea7e85a36"
+dependencies = [
+ "symbolic-common",
+ "symbolic-debuginfo",
+ "symbolic-demangle",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cccfffbc6bb3bb2d3a26cd2077f4d055f6808d266f9d4d158797a4c60510dfe"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-debuginfo"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb52777be67777947c5a159f1b6e8bfe4473d91fad7e5d4aff85ee4d3963cc04"
+dependencies = [
+ "debugid",
+ "dmsort",
+ "elementtree",
+ "elsa",
+ "fallible-iterator 0.3.0",
+ "flate2",
+ "gimli",
+ "goblin",
+ "lazy_static",
+ "nom",
+ "nom-supreme",
+ "once_cell",
+ "parking_lot",
+ "pdb-addr2line",
+ "regex",
+ "scroll",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "symbolic-common",
+ "symbolic-ppdb",
+ "thiserror",
+ "wasmparser",
+ "zip",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a99812da4020a67e76c4eb41f08c87364c14170495ff780f30dd519c221a68"
+dependencies = [
+ "cc",
+ "cpp_demangle",
+ "msvc-demangler",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
+name = "symbolic-ppdb"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dace84623ccc926886fc880c36e2a81af4b17f8276abc4d77dc947ca3c6c8f8c"
+dependencies = [
+ "flate2",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "symbolic-common",
+ "thiserror",
+ "uuid",
+ "watto",
 ]
 
 [[package]]
@@ -1513,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +2001,26 @@ name = "wasm-bindgen-shared"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+
+[[package]]
+name = "wasmparser"
+version = "0.118.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
+dependencies = [
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "watto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6746b5315e417144282a047ebb82260d45c92d09bf653fa9ec975e3809be942b"
+dependencies = [
+ "leb128",
+ "thiserror",
+]
 
 [[package]]
 name = "web-sys"
@@ -1723,4 +2146,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,7 @@ tree-sitter-asm = "0.1.0"
 once_cell = "1.18.0"
 lsp-textdocument = "0.3.2"
 dirs = "5.0.1"
+symbolic = { version = "12.8.0", features = ["demangle"] }
+symbolic-demangle = "12.8.0"
 
 # [dev-dependencies]

--- a/samples/demangling/a.cpp
+++ b/samples/demangling/a.cpp
@@ -1,0 +1,53 @@
+#include <cmath>
+#include <iostream>
+#include <range/v3/all.hpp> // Include the Range-v3 library for C++17 ranges
+#include <string>
+#include <vector>
+
+// This is a sample program to demonstrate the demangling capabilities of asm-lsp and the symbolic
+// rust crate.
+//
+// See the corresponding assembly code for this file (as compiled on Linux with g++ 11.4.0) in
+// `a.s`. To experiment with the demangling feature, in your editor hover over a label, like
+// `_ZnwmPv` and see what's the corresponding C++ function / definition (should show
+// `operator new(unsigned long, void*)`)
+int main()
+{
+  std::string inputStr;
+
+  // Prompt user to enter a string
+  std::cout << "Enter a string: ";
+  std::getline(std::cin, inputStr);
+
+  // Convert the string to a number (assuming ASCII values of characters)
+  unsigned long long int result = 0;
+  for (char c : inputStr)
+  {
+    result += static_cast<unsigned long long int>(pow(static_cast<unsigned char>(c), 3));
+  }
+
+  // Print the result
+  std::cout << "Result: " << result << std::endl;
+
+  // Create a vector of 10 strings
+  std::vector<std::string> strings(10, inputStr);
+
+  // Append a number to each string using C++17 ranges
+  auto appendedStrings = strings
+                         | ranges::views::transform(
+                             [](std::string str)
+                             {
+                               static int i = 1;
+                               str += std::to_string(i++); // Append numbers from 1 to 10
+                               return str;
+                             });
+
+  // Print the appended strings
+  std::cout << "Appended strings:\n";
+  for (const auto& str : appendedStrings)
+  {
+    std::cout << str << std::endl;
+  }
+
+  return 0;
+}

--- a/samples/demangling/a.s
+++ b/samples/demangling/a.s
@@ -1,0 +1,6881 @@
+	.file	"a.cpp"
+	.text
+	.section	.text._ZnwmPv,"axG",@progbits,_ZnwmPv,comdat
+	.weak	_ZnwmPv
+	.type	_ZnwmPv, @function
+_ZnwmPv:
+.LFB993:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE993:
+	.size	_ZnwmPv, .-_ZnwmPv
+	.section	.text._ZdlPvS_,"axG",@progbits,_ZdlPvS_,comdat
+	.weak	_ZdlPvS_
+	.type	_ZdlPvS_, @function
+_ZdlPvS_:
+.LFB995:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE995:
+	.size	_ZdlPvS_, .-_ZdlPvS_
+	.section	.text._ZNSt7__cxx119to_stringEi,"axG",@progbits,_ZNSt7__cxx119to_stringEi,comdat
+	.weak	_ZNSt7__cxx119to_stringEi
+	.type	_ZNSt7__cxx119to_stringEi, @function
+_ZNSt7__cxx119to_stringEi:
+.LFB1734:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA1734
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$56, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -56(%rbp)
+	movl	%esi, -60(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movl	-60(%rbp), %eax
+	shrl	$31, %eax
+	movb	%al, -33(%rbp)
+	cmpb	$0, -33(%rbp)
+	je	.L5
+	movl	-60(%rbp), %eax
+	negl	%eax
+	jmp	.L6
+.L5:
+	movl	-60(%rbp), %eax
+.L6:
+	movl	%eax, -32(%rbp)
+	movl	-32(%rbp), %eax
+	movl	$10, %esi
+	movl	%eax, %edi
+	call	_ZNSt8__detail14__to_chars_lenIjEEjT_i
+	movl	%eax, -28(%rbp)
+	leaq	-34(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaIcEC1Ev@PLT
+	movzbl	-33(%rbp), %edx
+	movl	-28(%rbp), %eax
+	addl	%edx, %eax
+	movl	%eax, %esi
+	leaq	-34(%rbp), %rdx
+	movq	-56(%rbp), %rax
+	movq	%rdx, %rcx
+	movl	$45, %edx
+	movq	%rax, %rdi
+.LEHB0:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1IS3_EEmcRKS3_
+.LEHE0:
+	leaq	-34(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaIcED1Ev@PLT
+	movzbl	-33(%rbp), %edx
+	movq	-56(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB1:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEixEm@PLT
+.LEHE1:
+	movq	%rax, %rcx
+	movl	-32(%rbp), %edx
+	movl	-28(%rbp), %eax
+	movl	%eax, %esi
+	movq	%rcx, %rdi
+	call	_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_
+	nop
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L10
+	jmp	.L13
+.L11:
+	endbr64
+	movq	%rax, %rbx
+	leaq	-34(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaIcED1Ev@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB2:
+	call	_Unwind_Resume@PLT
+.L12:
+	endbr64
+	movq	%rax, %rbx
+	movq	-56(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+	call	_Unwind_Resume@PLT
+.LEHE2:
+.L13:
+	call	__stack_chk_fail@PLT
+.L10:
+	movq	-56(%rbp), %rax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE1734:
+	.globl	__gxx_personality_v0
+	.section	.gcc_except_table._ZNSt7__cxx119to_stringEi,"aG",@progbits,_ZNSt7__cxx119to_stringEi,comdat
+.LLSDA1734:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE1734-.LLSDACSB1734
+.LLSDACSB1734:
+	.uleb128 .LEHB0-.LFB1734
+	.uleb128 .LEHE0-.LEHB0
+	.uleb128 .L11-.LFB1734
+	.uleb128 0
+	.uleb128 .LEHB1-.LFB1734
+	.uleb128 .LEHE1-.LEHB1
+	.uleb128 .L12-.LFB1734
+	.uleb128 0
+	.uleb128 .LEHB2-.LFB1734
+	.uleb128 .LEHE2-.LEHB2
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE1734:
+	.section	.text._ZNSt7__cxx119to_stringEi,"axG",@progbits,_ZNSt7__cxx119to_stringEi,comdat
+	.size	_ZNSt7__cxx119to_stringEi, .-_ZNSt7__cxx119to_stringEi
+	.section	.text._ZNSt8__detail14__to_chars_lenIjEEjT_i,"axG",@progbits,_ZNSt8__detail14__to_chars_lenIjEEjT_i,comdat
+	.weak	_ZNSt8__detail14__to_chars_lenIjEEjT_i
+	.type	_ZNSt8__detail14__to_chars_lenIjEEjT_i, @function
+_ZNSt8__detail14__to_chars_lenIjEEjT_i:
+.LFB1736:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movl	%edi, -36(%rbp)
+	movl	%esi, -40(%rbp)
+	movl	$1, -20(%rbp)
+	movl	-40(%rbp), %eax
+	imull	%eax, %eax
+	movl	%eax, -16(%rbp)
+	movl	-40(%rbp), %eax
+	movl	-16(%rbp), %edx
+	imull	%edx, %eax
+	movl	%eax, -12(%rbp)
+	movl	-40(%rbp), %eax
+	imull	-12(%rbp), %eax
+	movl	%eax, %eax
+	movq	%rax, -8(%rbp)
+.L20:
+	movl	-40(%rbp), %eax
+	cmpl	%eax, -36(%rbp)
+	jnb	.L15
+	movl	-20(%rbp), %eax
+	jmp	.L16
+.L15:
+	movl	-36(%rbp), %eax
+	cmpl	-16(%rbp), %eax
+	jnb	.L17
+	movl	-20(%rbp), %eax
+	addl	$1, %eax
+	jmp	.L16
+.L17:
+	movl	-36(%rbp), %eax
+	cmpl	-12(%rbp), %eax
+	jnb	.L18
+	movl	-20(%rbp), %eax
+	addl	$2, %eax
+	jmp	.L16
+.L18:
+	movl	-36(%rbp), %eax
+	cmpq	%rax, -8(%rbp)
+	jbe	.L19
+	movl	-20(%rbp), %eax
+	addl	$3, %eax
+	jmp	.L16
+.L19:
+	movl	-36(%rbp), %eax
+	movl	$0, %edx
+	divq	-8(%rbp)
+	movl	%eax, -36(%rbp)
+	addl	$4, -20(%rbp)
+	jmp	.L20
+.L16:
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE1736:
+	.size	_ZNSt8__detail14__to_chars_lenIjEEjT_i, .-_ZNSt8__detail14__to_chars_lenIjEEjT_i
+	.local	_ZStL8__ioinit
+	.comm	_ZStL8__ioinit,1,1
+	.section	.text._ZSt3minImERKT_S2_S2_,"axG",@progbits,_ZSt3minImERKT_S2_S2_,comdat
+	.weak	_ZSt3minImERKT_S2_S2_
+	.type	_ZSt3minImERKT_S2_S2_, @function
+_ZSt3minImERKT_S2_S2_:
+.LFB2773:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	cmpq	%rax, %rdx
+	jnb	.L22
+	movq	-16(%rbp), %rax
+	jmp	.L23
+.L22:
+	movq	-8(%rbp), %rax
+.L23:
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE2773:
+	.size	_ZSt3minImERKT_S2_S2_, .-_ZSt3minImERKT_S2_S2_
+	.weak	_ZN6ranges6invokeE
+	.section	.rodata._ZN6ranges6invokeE,"aG",@progbits,_ZN6ranges6invokeE,comdat
+	.type	_ZN6ranges6invokeE, @gnu_unique_object
+	.size	_ZN6ranges6invokeE, 1
+_ZN6ranges6invokeE:
+	.zero	1
+	.section	.rodata
+	.align 4
+	.type	_ZN9__gnu_cxxL21__default_lock_policyE, @object
+	.size	_ZN9__gnu_cxxL21__default_lock_policyE, 4
+_ZN9__gnu_cxxL21__default_lock_policyE:
+	.long	2
+	.type	_ZN6__pstl9execution2v1L3seqE, @object
+	.size	_ZN6__pstl9execution2v1L3seqE, 1
+_ZN6__pstl9execution2v1L3seqE:
+	.zero	1
+	.type	_ZN6__pstl9execution2v1L3parE, @object
+	.size	_ZN6__pstl9execution2v1L3parE, 1
+_ZN6__pstl9execution2v1L3parE:
+	.zero	1
+	.type	_ZN6__pstl9execution2v1L9par_unseqE, @object
+	.size	_ZN6__pstl9execution2v1L9par_unseqE, 1
+_ZN6__pstl9execution2v1L9par_unseqE:
+	.zero	1
+	.type	_ZN6__pstl9execution2v1L5unseqE, @object
+	.size	_ZN6__pstl9execution2v1L5unseqE, 1
+_ZN6__pstl9execution2v1L5unseqE:
+	.zero	1
+	.weak	_ZN6ranges1_5beginE
+	.section	.rodata._ZN6ranges1_5beginE,"aG",@progbits,_ZN6ranges1_5beginE,comdat
+	.type	_ZN6ranges1_5beginE, @gnu_unique_object
+	.size	_ZN6ranges1_5beginE, 1
+_ZN6ranges1_5beginE:
+	.zero	1
+	.weak	_ZN6ranges1_3endE
+	.section	.rodata._ZN6ranges1_3endE,"aG",@progbits,_ZN6ranges1_3endE,comdat
+	.type	_ZN6ranges1_3endE, @gnu_unique_object
+	.size	_ZN6ranges1_3endE, 1
+_ZN6ranges1_3endE:
+	.zero	1
+	.weak	_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE
+	.section	.rodata._ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE,"aG",@progbits,_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE,comdat
+	.type	_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE, @gnu_unique_object
+	.size	_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE, 1
+_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE:
+	.zero	1
+	.section	.data.rel.ro.local,"aw"
+	.align 8
+	.type	_ZN6ranges7actions12_GLOBAL__N_111make_actionE, @object
+	.size	_ZN6ranges7actions12_GLOBAL__N_111make_actionE, 8
+_ZN6ranges7actions12_GLOBAL__N_111make_actionE:
+	.quad	_ZN6ranges12static_constINS_7actions15make_action_fn_EE5valueE
+	.weak	_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE
+	.section	.rodata._ZN6ranges12static_constINS_12_sanitize_fnEE5valueE,"aG",@progbits,_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE,comdat
+	.type	_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE, @gnu_unique_object
+	.size	_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE, 1
+_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE:
+	.zero	1
+	.section	.data.rel.ro.local
+	.align 8
+	.type	_ZN6ranges12_GLOBAL__N_18sanitizeE, @object
+	.size	_ZN6ranges12_GLOBAL__N_18sanitizeE, 8
+_ZN6ranges12_GLOBAL__N_18sanitizeE:
+	.quad	_ZN6ranges12static_constINS_12_sanitize_fnEE5valueE
+	.weak	_ZN6ranges9bind_backE
+	.section	.rodata._ZN6ranges9bind_backE,"aG",@progbits,_ZN6ranges9bind_backE,comdat
+	.type	_ZN6ranges9bind_backE, @gnu_unique_object
+	.size	_ZN6ranges9bind_backE, 1
+_ZN6ranges9bind_backE:
+	.zero	1
+	.weak	_ZN6ranges5views3refE
+	.section	.rodata._ZN6ranges5views3refE,"aG",@progbits,_ZN6ranges5views3refE,comdat
+	.type	_ZN6ranges5views3refE, @gnu_unique_object
+	.size	_ZN6ranges5views3refE, 1
+_ZN6ranges5views3refE:
+	.zero	1
+	.weak	_ZN6ranges17make_view_closureE
+	.section	.rodata._ZN6ranges17make_view_closureE,"aG",@progbits,_ZN6ranges17make_view_closureE,comdat
+	.type	_ZN6ranges17make_view_closureE, @gnu_unique_object
+	.size	_ZN6ranges17make_view_closureE, 1
+_ZN6ranges17make_view_closureE:
+	.zero	1
+	.weak	_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE
+	.section	.rodata._ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE,"aG",@progbits,_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE,comdat
+	.type	_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE, @gnu_unique_object
+	.size	_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE, 1
+_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE:
+	.zero	1
+	.section	.data.rel.ro.local
+	.align 8
+	.type	_ZN6ranges5views12_GLOBAL__N_19make_viewE, @object
+	.size	_ZN6ranges5views12_GLOBAL__N_19make_viewE, 8
+_ZN6ranges5views12_GLOBAL__N_19make_viewE:
+	.quad	_ZN6ranges12static_constINS_5views13make_view_fn_EE5valueE
+	.weak	_ZN6ranges5views3allE
+	.section	.rodata._ZN6ranges5views3allE,"aG",@progbits,_ZN6ranges5views3allE,comdat
+	.type	_ZN6ranges5views3allE, @gnu_unique_object
+	.size	_ZN6ranges5views3allE, 1
+_ZN6ranges5views3allE:
+	.zero	1
+	.weak	_ZN6ranges8indirectE
+	.section	.rodata._ZN6ranges8indirectE,"aG",@progbits,_ZN6ranges8indirectE,comdat
+	.type	_ZN6ranges8indirectE, @gnu_unique_object
+	.size	_ZN6ranges8indirectE, 1
+_ZN6ranges8indirectE:
+	.zero	1
+	.weak	_ZN6ranges5views9transformE
+	.section	.rodata._ZN6ranges5views9transformE,"aG",@progbits,_ZN6ranges5views9transformE,comdat
+	.type	_ZN6ranges5views9transformE, @gnu_unique_object
+	.size	_ZN6ranges5views9transformE, 1
+_ZN6ranges5views9transformE:
+	.zero	1
+	.weak	_ZN6ranges5views6commonE
+	.section	.rodata._ZN6ranges5views6commonE,"aG",@progbits,_ZN6ranges5views6commonE,comdat
+	.type	_ZN6ranges5views6commonE, @gnu_unique_object
+	.size	_ZN6ranges5views6commonE, 1
+_ZN6ranges5views6commonE:
+	.zero	1
+	.section	.data.rel.ro.local
+	.align 8
+	.type	_ZN6ranges5views12_GLOBAL__N_17boundedE, @object
+	.size	_ZN6ranges5views12_GLOBAL__N_17boundedE, 8
+_ZN6ranges5views12_GLOBAL__N_17boundedE:
+	.quad	_ZN6ranges5views6commonE
+	.section	.rodata
+	.align 8
+	.type	_ZN6rangesL14dynamic_extentE, @object
+	.size	_ZN6rangesL14dynamic_extentE, 8
+_ZN6rangesL14dynamic_extentE:
+	.quad	-1
+	.align 4
+	.type	_ZNSt15regex_constantsL13error_collateE, @object
+	.size	_ZNSt15regex_constantsL13error_collateE, 4
+_ZNSt15regex_constantsL13error_collateE:
+	.zero	4
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_ctypeE, @object
+	.size	_ZNSt15regex_constantsL11error_ctypeE, 4
+_ZNSt15regex_constantsL11error_ctypeE:
+	.long	1
+	.align 4
+	.type	_ZNSt15regex_constantsL12error_escapeE, @object
+	.size	_ZNSt15regex_constantsL12error_escapeE, 4
+_ZNSt15regex_constantsL12error_escapeE:
+	.long	2
+	.align 4
+	.type	_ZNSt15regex_constantsL13error_backrefE, @object
+	.size	_ZNSt15regex_constantsL13error_backrefE, 4
+_ZNSt15regex_constantsL13error_backrefE:
+	.long	3
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_brackE, @object
+	.size	_ZNSt15regex_constantsL11error_brackE, 4
+_ZNSt15regex_constantsL11error_brackE:
+	.long	4
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_parenE, @object
+	.size	_ZNSt15regex_constantsL11error_parenE, 4
+_ZNSt15regex_constantsL11error_parenE:
+	.long	5
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_braceE, @object
+	.size	_ZNSt15regex_constantsL11error_braceE, 4
+_ZNSt15regex_constantsL11error_braceE:
+	.long	6
+	.align 4
+	.type	_ZNSt15regex_constantsL14error_badbraceE, @object
+	.size	_ZNSt15regex_constantsL14error_badbraceE, 4
+_ZNSt15regex_constantsL14error_badbraceE:
+	.long	7
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_rangeE, @object
+	.size	_ZNSt15regex_constantsL11error_rangeE, 4
+_ZNSt15regex_constantsL11error_rangeE:
+	.long	8
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_spaceE, @object
+	.size	_ZNSt15regex_constantsL11error_spaceE, 4
+_ZNSt15regex_constantsL11error_spaceE:
+	.long	9
+	.align 4
+	.type	_ZNSt15regex_constantsL15error_badrepeatE, @object
+	.size	_ZNSt15regex_constantsL15error_badrepeatE, 4
+_ZNSt15regex_constantsL15error_badrepeatE:
+	.long	10
+	.align 4
+	.type	_ZNSt15regex_constantsL16error_complexityE, @object
+	.size	_ZNSt15regex_constantsL16error_complexityE, 4
+_ZNSt15regex_constantsL16error_complexityE:
+	.long	11
+	.align 4
+	.type	_ZNSt15regex_constantsL11error_stackE, @object
+	.size	_ZNSt15regex_constantsL11error_stackE, 4
+_ZNSt15regex_constantsL11error_stackE:
+	.long	12
+	.align 8
+	.type	_ZNSt8__detailL19_S_invalid_state_idE, @object
+	.size	_ZNSt8__detailL19_S_invalid_state_idE, 8
+_ZNSt8__detailL19_S_invalid_state_idE:
+	.quad	-1
+	.data
+	.align 4
+	.type	_ZZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_E1i, @object
+	.size	_ZZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_E1i, 4
+_ZZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_E1i:
+	.long	1
+	.text
+	.align 2
+	.type	_ZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_, @function
+_ZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_:
+.LFB9255:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9255
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$88, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -72(%rbp)
+	movq	%rsi, -80(%rbp)
+	movq	%rdx, -88(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movl	_ZZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_E1i(%rip), %eax
+	leal	1(%rax), %edx
+	movl	%edx, _ZZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_E1i(%rip)
+	leaq	-64(%rbp), %rdx
+	movl	%eax, %esi
+	movq	%rdx, %rdi
+.LEHB3:
+	call	_ZNSt7__cxx119to_stringEi
+.LEHE3:
+	leaq	-64(%rbp), %rdx
+	movq	-88(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB4:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEpLERKS4_@PLT
+.LEHE4:
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	-88(%rbp), %rdx
+	movq	-72(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_@PLT
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L27
+	jmp	.L29
+.L28:
+	endbr64
+	movq	%rax, %rbx
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB5:
+	call	_Unwind_Resume@PLT
+.LEHE5:
+.L29:
+	call	__stack_chk_fail@PLT
+.L27:
+	movq	-72(%rbp), %rax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9255:
+	.section	.gcc_except_table,"a",@progbits
+.LLSDA9255:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9255-.LLSDACSB9255
+.LLSDACSB9255:
+	.uleb128 .LEHB3-.LFB9255
+	.uleb128 .LEHE3-.LEHB3
+	.uleb128 0
+	.uleb128 0
+	.uleb128 .LEHB4-.LFB9255
+	.uleb128 .LEHE4-.LEHB4
+	.uleb128 .L28-.LFB9255
+	.uleb128 0
+	.uleb128 .LEHB5-.LFB9255
+	.uleb128 .LEHE5-.LEHB5
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE9255:
+	.text
+	.size	_ZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_, .-_ZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_
+	.align 2
+	.type	_ZNK6ranges5views12transform_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEDaT_, @function
+_ZNK6ranges5views12transform_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEDaT_:
+.LFB9258:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	leaq	-41(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_
+	movq	%rax, %rdx
+	leaq	-25(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges9bind_backE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges12bind_back_fnclINS_5views17transform_base_fnEZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JEEENS_6detail13bind_back_fn_INSt5decayIT_E4typeEJNSD_IT0_E4typeEDpNSD_IT1_E4typeEEEEOSE_OSH_DpOSK_
+	leaq	_ZN6ranges17make_view_closureE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges20make_view_closure_fnclINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEENS4_12view_closureIT_EESF_
+	nop
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L32
+	call	__stack_chk_fail@PLT
+.L32:
+	movl	%ebx, %eax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9258:
+	.size	_ZNK6ranges5views12transform_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEDaT_, .-_ZNK6ranges5views12transform_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEDaT_
+	.section	.rodata
+	.type	_ZN6ranges22invocable_view_closureINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEERSt6vectorISA_SaISA_EEEE, @object
+	.size	_ZN6ranges22invocable_view_closureINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEERSt6vectorISA_SaISA_EEEE, 1
+_ZN6ranges22invocable_view_closureINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEERSt6vectorISA_SaISA_EEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEJRSt6vectorISA_SaISA_EEEEE, @object
+	.size	_ZN6ranges9invocableINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEJRSt6vectorISA_SaISA_EEEEE, 1
+_ZN6ranges9invocableINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEJRSt6vectorISA_SaISA_EEEEE:
+	.byte	1
+	.type	_ZN6ranges5views19transformable_rangeIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEZ4mainEUlS8_E_EE, @object
+	.size	_ZN6ranges5views19transformable_rangeIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEZ4mainEUlS8_E_EE, 1
+_ZN6ranges5views19transformable_rangeIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEZ4mainEUlS8_E_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18copy_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, @object
+	.size	_ZN8concepts4defs18copy_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, 1
+_ZN8concepts4defs18copy_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18move_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, @object
+	.size	_ZN8concepts4defs18move_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, 1
+_ZN8concepts4defs18move_constructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JS8_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JS8_EEE, 1
+_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JS8_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, @object
+	.size	_ZN8concepts4defs12destructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE, 1
+_ZN8concepts4defs12destructibleIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs14convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS8_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS8_EEE, 1
+_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS8_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRKS8_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRKS8_EEE, 1
+_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRKS8_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JKS8_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JKS8_EEE, 1
+_ZN8concepts4defs18constructible_fromIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JKS8_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs14convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs14convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs14convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIKZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_S8_EE:
+	.byte	1
+	.type	_ZN6ranges17regular_invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE, @object
+	.size	_ZN6ranges17regular_invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE, 1
+_ZN6ranges17regular_invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE, @object
+	.size	_ZN6ranges9invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE, 1
+_ZN6ranges9invocableIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS6_EEE:
+	.byte	1
+	.section	.text._ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE,"axG",@progbits,_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE,comdat
+	.weak	_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE
+	.type	_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE, @function
+_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE:
+.LFB9269:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges5views3refE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9269:
+	.size	_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE, .-_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE
+	.section	.text._ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_,"axG",@progbits,_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_,comdat
+	.align 2
+	.weak	_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_
+	.type	_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_, @function
+_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_:
+.LFB9268:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	leaq	-10(%rbp), %rdx
+	leaq	-9(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail8ignore_tC1ISt17integral_constantIbLb1EEEEOT_
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges5views6all_fn11from_range_IRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEEDaOT_St17integral_constantIbLb0EESF_IbLb1EENS_6detail8ignore_tE
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L37
+	call	__stack_chk_fail@PLT
+.L37:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9268:
+	.size	_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_, .-_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_
+	.section	.text._ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_,"axG",@progbits,_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_,comdat
+	.weak	_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_
+	.type	_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_, @function
+_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_:
+.LFB9273:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9273:
+	.size	_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_, .-_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_
+	.section	.text._ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_,"axG",@progbits,_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_,comdat
+	.align 2
+	.weak	_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_
+	.type	_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_, @function
+_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_:
+.LFB9272:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	leaq	-11(%rbp), %rdx
+	leaq	-9(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail8ignore_tC1ISt17integral_constantIbLb1EEEEOT_
+	leaq	-12(%rbp), %rdx
+	leaq	-10(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail8ignore_tC1ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges5views6all_fn11from_range_INS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEEEEDaOT_St17integral_constantIbLb1EENS_6detail8ignore_tESJ_
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L42
+	call	__stack_chk_fail@PLT
+.L42:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9272:
+	.size	_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_, .-_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_
+	.section	.rodata
+	.type	_ZN8concepts4defs11semiregularIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs11semiregularIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs11semiregularIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs8copyableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs8copyableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs8copyableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs18copy_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs18copy_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs18copy_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18move_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs18move_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs18move_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJSB_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJSB_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJSB_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs14convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRSB_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRSB_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRSB_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRKSB_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRKSB_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRKSB_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJKSB_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJKSB_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJKSB_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs14convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs14convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7movableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs7movableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs7movableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESB_EE:
+	.zero	1
+	.type	_ZN8concepts4defs21common_reference_withIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, @object
+	.size	_ZN8concepts4defs21common_reference_withIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, 1
+_ZN8concepts4defs21common_reference_withIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, @object
+	.size	_ZN8concepts4defs7same_asIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, 1
+_ZN8concepts4defs7same_asIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESD_EE:
+	.byte	1
+	.type	_ZN8concepts4defs9swappableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs9swappableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs9swappableIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESC_EE, @object
+	.size	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESC_EE, 1
+_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EESC_EE:
+	.zero	1
+	.type	_ZN8concepts6detail12is_movable_vIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts6detail12is_movable_vIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts6detail12is_movable_vIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EERKSB_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EERKSB_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EERKSB_EE:
+	.zero	1
+	.type	_ZN8concepts4defs21default_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, @object
+	.size	_ZN8concepts4defs21default_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE, 1
+_ZN8concepts4defs21default_constructibleIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJEEE:
+	.zero	1
+	.type	_ZN6ranges22is_nothrow_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE, @object
+	.size	_ZN6ranges22is_nothrow_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE, 1
+_ZN6ranges22is_nothrow_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE:
+	.zero	1
+	.type	_ZN6ranges14is_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE, @object
+	.size	_ZN6ranges14is_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE, 1
+_ZN6ranges14is_invocable_vINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_EEE:
+	.byte	1
+	.type	_ZN4meta10is_trait_vIN6ranges13invoke_resultINS1_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEZ4mainEUlSB_E_EEEEE, @object
+	.size	_ZN4meta10is_trait_vIN6ranges13invoke_resultINS1_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEZ4mainEUlSB_E_EEEEE, 1
+_ZN4meta10is_trait_vIN6ranges13invoke_resultINS1_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEZ4mainEUlSB_E_EEEEE:
+	.byte	1
+	.type	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultINS2_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEZ4mainEUlSC_E_EEEvEE, @object
+	.size	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultINS2_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEZ4mainEUlSC_E_EEEvEE, 1
+_ZN4meta6detail9is_trait_IN6ranges13invoke_resultINS2_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEZ4mainEUlSC_E_EEEvEE:
+	.byte	1
+	.type	_ZN8concepts4defs12derived_fromIN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EENS2_6detail18view_closure_base_EEE, @object
+	.size	_ZN8concepts4defs12derived_fromIN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EENS2_6detail18view_closure_base_EEE, 1
+_ZN8concepts4defs12derived_fromIN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EENS2_6detail18view_closure_base_EEE:
+	.zero	1
+	.type	_ZN8concepts4defs14convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, @object
+	.size	_ZN8concepts4defs14convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, 1
+_ZN8concepts4defs14convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE:
+	.zero	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, 1
+_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE:
+	.zero	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE, 1
+_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges14transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEZ4mainEUlSB_E_EEPVKNS2_6detail18view_closure_base_EEE:
+	.zero	1
+	.text
+	.align 2
+	.type	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEED2Ev, @function
+_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEED2Ev:
+.LFB9280:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	addq	$16, %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED1Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9280:
+	.size	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEED2Ev, .-_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEED2Ev
+	.align 2
+	.type	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED2Ev, @function
+_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED2Ev:
+.LFB9282:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEED2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9282:
+	.size	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED2Ev, .-_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED2Ev
+	.set	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED1Ev,_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED2Ev
+	.type	_ZN6ranges5views20view_closure_base_nsorIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EENS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlS9_E_EEELb1ELi0ELi0EEEDaOT_NS0_12view_closureIT0_EE, @function
+_ZN6ranges5views20view_closure_base_nsorIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EENS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlS9_E_EEELb1ELi0ELi0EEEDaOT_NS0_12view_closureIT0_EE:
+.LFB9277:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-32(%rbp), %rdx
+	leaq	-34(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNO6ranges6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEclIJRSt6vectorIS9_SaIS9_EEEEEDTclL_ZNS_6invokeEEcl7declvalIS3_EEspcl7declvalIT_EEcl7declvalISA_EEEEDpOSH_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L47
+	call	__stack_chk_fail@PLT
+.L47:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9277:
+	.size	_ZN6ranges5views20view_closure_base_nsorIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EENS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlS9_E_EEELb1ELi0ELi0EEEDaOT_NS0_12view_closureIT0_EE, .-_ZN6ranges5views20view_closure_base_nsorIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EENS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlS9_E_EEELb1ELi0ELi0EEEDaOT_NS0_12view_closureIT0_EE
+	.section	.rodata
+	.type	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEESI_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEESI_EE, 1
+_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEESI_EE:
+	.byte	1
+	.type	_ZN6ranges6detail25iter_transform_1_readableIKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEKNS_8ref_viewISt6vectorIS8_SaIS8_EEEEEE, @object
+	.size	_ZN6ranges6detail25iter_transform_1_readableIKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEKNS_8ref_viewISt6vectorIS8_SaIS8_EEEEEE, 1
+_ZN6ranges6detail25iter_transform_1_readableIKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEKNS_8ref_viewISt6vectorIS8_SaIS8_EEEEEE:
+	.byte	1
+	.type	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8copy_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges17regular_invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagEN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, @object
+	.size	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, 1
+_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE:
+	.byte	1
+	.type	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, @object
+	.size	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, 1
+_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE:
+	.byte	1
+	.type	_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges9invocableIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges22is_nothrow_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges14is_invocable_vIRKNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, @object
+	.size	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, 1
+_ZN4meta10is_trait_vIN6ranges13invoke_resultIRKNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE:
+	.byte	1
+	.type	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, @object
+	.size	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, 1
+_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRKNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE:
+	.byte	1
+	.type	_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb1EEEEE, @object
+	.size	_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb1EEEEE, 1
+_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb1EEEEE:
+	.zero	1
+	.type	_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, @object
+	.size	_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, 1
+_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE:
+	.byte	1
+	.type	_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, @object
+	.size	_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, 1
+_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE:
+	.zero	1
+	.type	_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, @object
+	.size	_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE, 1
+_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb1EEEE:
+	.zero	1
+	.type	_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, @object
+	.size	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, 1
+_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE:
+	.byte	1
+	.type	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, @object
+	.size	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, 1
+_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE:
+	.byte	1
+	.text
+	.align 2
+	.type	_ZNR6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEclIJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEELb1ELi0EEEDcDpOT_, @function
+_ZNR6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEclIJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEELb1ELi0EEEDcDpOT_:
+.LFB9296:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rdx
+	movq	-24(%rbp), %rax
+	movq	-40(%rbp), %rcx
+	leaq	_ZN6ranges6invokeE(%rip), %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges9invoke_fnclIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESL_DpSN_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L50
+	call	__stack_chk_fail@PLT
+.L50:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9296:
+	.size	_ZNR6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEclIJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEELb1ELi0EEEDcDpOT_, .-_ZNR6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEclIJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEELb1ELi0EEEDcDpOT_
+	.section	.rodata
+	.type	_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges22is_nothrow_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, @object
+	.size	_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE, 1
+_ZN6ranges14is_invocable_vIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS_8move_tagERN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEEEE:
+	.byte	1
+	.type	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, @object
+	.size	_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE, 1
+_ZN4meta10is_trait_vIN6ranges13invoke_resultIRNS1_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS1_8move_tagERN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEEE:
+	.byte	1
+	.type	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, @object
+	.size	_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE, 1
+_ZN4meta6detail9is_trait_IN6ranges13invoke_resultIRNS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_8move_tagERN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEvEE:
+	.byte	1
+	.type	_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEE, @object
+	.size	_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEE, 1
+_ZN6ranges6detail12is_trivial_vINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEE:
+	.zero	1
+	.type	_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, @object
+	.size	_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, 1
+_ZSt23is_trivially_copyable_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE:
+	.byte	1
+	.type	_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, @object
+	.size	_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, 1
+_ZSt36is_trivially_default_constructible_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE:
+	.zero	1
+	.type	_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, @object
+	.size	_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE, 1
+_ZSt10is_final_vIN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEE:
+	.zero	1
+	.type	_ZN6ranges6detail15readable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail15readable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail15readable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail18cpp17_input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail18cpp17_input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail18cpp17_input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail12input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail12input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail12input_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail6cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail6cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail6cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJSQ_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRSQ_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRKSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRKSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJRKSQ_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJKSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJKSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJKSQ_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, @object
+	.size	_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, 1
+_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, @object
+	.size	_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, 1
+_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE, @object
+	.size	_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE, 1
+_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE, @object
+	.size	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE, 1
+_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEESR_EE:
+	.zero	1
+	.type	_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEERKSQ_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEERKSQ_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEERKSQ_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEJEEE:
+	.byte	1
+	.type	_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs11semiregularIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs8copyableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs18copy_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs18move_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSR_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSR_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSR_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN6ranges6detail12is_trivial_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail12is_trivial_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail12is_trivial_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZSt23is_trivially_copyable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, @object
+	.size	_ZSt23is_trivially_copyable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, 1
+_ZSt23is_trivially_copyable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE:
+	.byte	1
+	.type	_ZSt36is_trivially_default_constructible_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, @object
+	.size	_ZSt36is_trivially_default_constructible_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, 1
+_ZSt36is_trivially_default_constructible_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE:
+	.zero	1
+	.type	_ZSt10is_final_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, @object
+	.size	_ZSt10is_final_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE, 1
+_ZSt10is_final_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS0_19iter_transform_viewINS0_8ref_viewISD_EENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE:
+	.zero	1
+	.type	_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs14convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRSR_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRSR_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRSR_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSR_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSR_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSR_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJKSR_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJKSR_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJKSR_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs14convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs14convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs7movableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, @object
+	.size	_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, 1
+_ZN8concepts4defs21common_reference_withIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, @object
+	.size	_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, 1
+_ZN8concepts4defs7same_asIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE, @object
+	.size	_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE, 1
+_ZN8concepts4defs7same_asIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs9swappableIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE, @object
+	.size	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE, 1
+_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinESS_EE:
+	.zero	1
+	.type	_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts6detail12is_movable_vIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinERKSR_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinERKSR_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinERKSR_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, @object
+	.size	_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE, 1
+_ZN8concepts4defs21default_constructibleIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJSQ_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSQ_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSQ_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinEJRKSQ_EEE:
+	.byte	1
+	.type	_ZN6ranges6detail15has_cursor_nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail15has_cursor_nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail15has_cursor_nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail19sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE, @object
+	.size	_ZN6ranges6detail19sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE, 1
+_ZN6ranges6detail19sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE:
+	.byte	1
+	.type	_ZN6ranges6detail20random_access_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail20random_access_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail20random_access_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail20bidirectional_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail20bidirectional_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail20bidirectional_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail14forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail14forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail14forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail25sized_sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE, @object
+	.size	_ZN6ranges6detail25sized_sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE, 1
+_ZN6ranges6detail25sized_sentinel_for_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EE:
+	.byte	1
+	.type	_ZN6ranges6detail20cpp17_forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail20cpp17_forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail20cpp17_forward_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges6detail20is_writable_cursor_vIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail20is_writable_cursor_vIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail20is_writable_cursor_vIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges6detail15readable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail15readable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail15readable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.byte	1
+	.type	_ZN6ranges6detail19is_writable_cursor_IKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE, @object
+	.size	_ZN6ranges6detail19is_writable_cursor_IKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE, 1
+_ZN6ranges6detail19is_writable_cursor_IKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE:
+	.zero	1
+	.type	_ZN6ranges6detail15writable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE, @object
+	.size	_ZN6ranges6detail15writable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE, 1
+_ZN6ranges6detail15writable_cursorIKNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE:
+	.zero	1
+	.type	_ZN6ranges6detail20is_writable_cursor_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail20is_writable_cursor_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail20is_writable_cursor_vINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges6detail19is_writable_cursor_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE, @object
+	.size	_ZN6ranges6detail19is_writable_cursor_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE, 1
+_ZN6ranges6detail19is_writable_cursor_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEE:
+	.zero	1
+	.type	_ZN6ranges6detail15writable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE, @object
+	.size	_ZN6ranges6detail15writable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE, 1
+_ZN6ranges6detail15writable_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESA_EE:
+	.zero	1
+	.type	_ZN6ranges6detail17contiguous_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail17contiguous_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail17contiguous_cursorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZN6ranges6detail16has_cursor_arrowINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, @object
+	.size	_ZN6ranges6detail16has_cursor_arrowINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE, 1
+_ZN6ranges6detail16has_cursor_arrowINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEE:
+	.zero	1
+	.type	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEESK_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEESK_EE, 1
+_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEESK_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, 1
+_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEEEESQ_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEEEESQ_EE, 1
+_ZN8concepts4defs7same_asIN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS2_19iter_transform_viewINS2_8ref_viewISF_EENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb1EEEEESQ_EE:
+	.byte	1
+	.type	_ZN6ranges6detail19sentinel_for_cursorINS_14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS_19iter_transform_viewINS_8ref_viewISF_EENS_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEESQ_EE, @object
+	.size	_ZN6ranges6detail19sentinel_for_cursorINS_14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS_19iter_transform_viewINS_8ref_viewISF_EENS_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEESQ_EE, 1
+_ZN6ranges6detail19sentinel_for_cursorINS_14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISB_SaISB_EEEENS_19iter_transform_viewINS_8ref_viewISF_EENS_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEEEESQ_EE:
+	.zero	1
+	.type	_ZN8concepts4defs11semiregularIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs11semiregularIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs11semiregularIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs8copyableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs8copyableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs8copyableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18copy_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs18copy_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs18copy_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18move_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs18move_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs18move_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJSS_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJSS_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJSS_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs14convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRSS_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRSS_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRSS_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRKSS_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRKSS_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJRKSS_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJKSS_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJKSS_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJKSS_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs14convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs14convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7movableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs7movableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs7movableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21common_reference_withIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, @object
+	.size	_ZN8concepts4defs21common_reference_withIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, 1
+_ZN8concepts4defs21common_reference_withIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, @object
+	.size	_ZN8concepts4defs7same_asIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, 1
+_ZN8concepts4defs7same_asIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, 1
+_ZN8concepts4defs14convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIRKN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEESU_EE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE, @object
+	.size	_ZN8concepts4defs7same_asIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE, 1
+_ZN8concepts4defs7same_asIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE:
+	.byte	1
+	.type	_ZN8concepts4defs9swappableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs9swappableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs9swappableIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE, @object
+	.size	_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE, 1
+_ZN8concepts15adl_swap_detail18is_adl_swappable_vIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEST_EE:
+	.zero	1
+	.type	_ZN8concepts6detail12is_movable_vIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts6detail12is_movable_vIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts6detail12is_movable_vIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEERKSS_EE, @object
+	.size	_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEERKSS_EE, 1
+_ZN8concepts4defs15assignable_fromIRN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEERKSS_EE:
+	.byte	1
+	.type	_ZN8concepts4defs21default_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, @object
+	.size	_ZN8concepts4defs21default_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE, 1
+_ZN8concepts4defs21default_constructibleIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges14basic_iteratorINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEEEJEEE:
+	.byte	1
+	.text
+	.type	_ZN6rangesneINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE, @function
+_ZN6rangesneINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE:
+.LFB9312:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6rangeseqINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE
+	xorl	$1, %eax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9312:
+	.size	_ZN6rangesneINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE, .-_ZN6rangesneINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE
+	.type	_ZN6rangeseqINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE, @function
+_ZN6rangeseqINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE:
+.LFB9313:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE
+	movq	%rax, %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access5equalINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EEDTcldtfp_5equalfp0_EERKT_RKT0_
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9313:
+	.size	_ZN6rangeseqINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE, .-_ZN6rangeseqINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE
+	.type	_ZN6ranges12range_access5equalINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EEDTcldtfp_5equalfp0_EERKT_RKT0_, @function
+_ZN6ranges12range_access5equalINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EEDTcldtfp_5equalfp0_EERKT_RKT0_:
+.LFB9314:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5equalISN_EEDTcldtcl7declvalIRKT_EE6equal_fp_Li42EEERKSN_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9314:
+	.size	_ZN6ranges12range_access5equalINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EEDTcldtfp_5equalfp0_EERKT_RKT0_, .-_ZN6ranges12range_access5equalINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEESP_EEDTcldtfp_5equalfp0_EERKT_RKT0_
+	.align 2
+	.type	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEppIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaL_ZNS_6detail15has_cursor_nextISO_EEEclT_tlST_EEEvE4typeEE6invokeIRSP_EEv, @function
+_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEppIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaL_ZNS_6detail15has_cursor_nextISO_EEEclT_tlST_EEEvE4typeEE6invokeIRSP_EEv:
+.LFB9315:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access4nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4nextEERT_
+	movq	-8(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9315:
+	.size	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEppIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaL_ZNS_6detail15has_cursor_nextISO_EEEclT_tlST_EEEvE4typeEE6invokeIRSP_EEv, .-_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEppIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaL_ZNS_6detail15has_cursor_nextISO_EEEclT_tlST_EEEvE4typeEE6invokeIRSP_EEv
+	.align 2
+	.type	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEdeIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaaaL_ZNS_6detail15readable_cursorISO_EEEntL_ZNSW_20is_writable_cursor_vISO_EEEclT_tlST_EEEvE4typeEE6invokeIS9_EEv, @function
+_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEdeIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaaaL_ZNS_6detail15readable_cursorISO_EEEntL_ZNSW_20is_writable_cursor_vISO_EEEclT_tlST_EEEvE4typeEE6invokeIS9_EEv:
+.LFB9316:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv
+	movq	%rax, %rdx
+	movq	-24(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access4readINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4readEERKT_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L61
+	call	__stack_chk_fail@PLT
+.L61:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9316:
+	.size	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEdeIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaaaL_ZNS_6detail15readable_cursorISO_EEEntL_ZNSW_20is_writable_cursor_vISO_EEEclT_tlST_EEEvE4typeEE6invokeIS9_EEv, .-_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEdeIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaaaL_ZNS_6detail15readable_cursorISO_EEEntL_ZNSW_20is_writable_cursor_vISO_EEEclT_tlST_EEEvE4typeEE6invokeIS9_EEv
+	.section	.rodata
+.LC0:
+	.string	"Enter a string: "
+.LC3:
+	.string	"Result: "
+.LC4:
+	.string	"Appended strings:\n"
+	.text
+	.globl	main
+	.type	main, @function
+main:
+.LFB9254:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9254
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$232, %rsp
+	.cfi_offset 3, -24
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	leaq	-96(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1Ev@PLT
+	leaq	.LC0(%rip), %rax
+	movq	%rax, %rsi
+	leaq	_ZSt4cout(%rip), %rax
+	movq	%rax, %rdi
+.LEHB6:
+	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc@PLT
+	leaq	-96(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZSt3cin(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE@PLT
+	movq	$0, -224(%rbp)
+	leaq	-96(%rbp), %rax
+	movq	%rax, -216(%rbp)
+	movq	-216(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5beginEv@PLT
+	movq	%rax, -160(%rbp)
+	movq	-216(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE3endEv@PLT
+	movq	%rax, -128(%rbp)
+	jmp	.L63
+.L66:
+	leaq	-160(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv
+	movzbl	(%rax), %eax
+	movb	%al, -225(%rbp)
+	movzbl	-225(%rbp), %eax
+	movzbl	%al, %eax
+	pxor	%xmm2, %xmm2
+	cvtsi2sdl	%eax, %xmm2
+	movq	%xmm2, %rax
+	movsd	.LC1(%rip), %xmm0
+	movapd	%xmm0, %xmm1
+	movq	%rax, %xmm0
+	call	pow@PLT
+	comisd	.LC2(%rip), %xmm0
+	jnb	.L64
+	cvttsd2siq	%xmm0, %rax
+	jmp	.L65
+.L64:
+	movsd	.LC2(%rip), %xmm1
+	subsd	%xmm1, %xmm0
+	cvttsd2siq	%xmm0, %rax
+	movabsq	$-9223372036854775808, %rdx
+	xorq	%rdx, %rax
+.L65:
+	addq	%rax, -224(%rbp)
+	leaq	-160(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv
+.L63:
+	leaq	-128(%rbp), %rdx
+	leaq	-160(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_
+	testb	%al, %al
+	jne	.L66
+	leaq	.LC3(%rip), %rax
+	movq	%rax, %rsi
+	leaq	_ZSt4cout(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc@PLT
+	movq	%rax, %rdx
+	movq	-224(%rbp), %rax
+	movq	%rax, %rsi
+	movq	%rdx, %rdi
+	call	_ZNSolsEy@PLT
+	movq	_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_@GOTPCREL(%rip), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSolsEPFRSoS_E@PLT
+.LEHE6:
+	leaq	-128(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1Ev
+	leaq	-128(%rbp), %rcx
+	leaq	-96(%rbp), %rdx
+	leaq	-160(%rbp), %rax
+	movl	$10, %esi
+	movq	%rax, %rdi
+.LEHB7:
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1EmRKS5_RKS6_
+.LEHE7:
+	leaq	-128(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev
+	leaq	_ZN6ranges5views9transformE(%rip), %rax
+	movq	%rax, %rdi
+.LEHB8:
+	call	_ZNK6ranges5views12transform_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEDaT_
+	leaq	-128(%rbp), %rax
+	leaq	-160(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges5views20view_closure_base_nsorIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EENS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlS9_E_EEELb1ELi0ELi0EEEDaOT_NS0_12view_closureIT0_EE
+.LEHE8:
+	leaq	.LC4(%rip), %rax
+	movq	%rax, %rsi
+	leaq	_ZSt4cout(%rip), %rax
+	movq	%rax, %rdi
+.LEHB9:
+	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc@PLT
+	leaq	-128(%rbp), %rax
+	movq	%rax, -208(%rbp)
+	movq	-208(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE5beginISG_Lb1ELi0EEENS_14basic_iteratorINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeEEEv
+	movq	%rax, -192(%rbp)
+	movq	%rdx, -184(%rbp)
+	movq	-208(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE3endISG_Lb1ELi0EEEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbX7same_asINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeENSP_IDTclsrSQ_10end_cursorcl7declvalISS_EEEEE4typeEEEENS_14basic_iteratorISV_EESY_EEESO_IbLb1EEE4typeEv
+	movq	%rax, -176(%rbp)
+	movq	%rdx, -168(%rbp)
+	jmp	.L67
+.L68:
+	leaq	-64(%rbp), %rax
+	leaq	-192(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEdeIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaaaL_ZNS_6detail15readable_cursorISO_EEEntL_ZNSW_20is_writable_cursor_vISO_EEEclT_tlST_EEEvE4typeEE6invokeIS9_EEv
+.LEHE9:
+	leaq	-64(%rbp), %rax
+	movq	%rax, -200(%rbp)
+	movq	-200(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZSt4cout(%rip), %rax
+	movq	%rax, %rdi
+.LEHB10:
+	call	_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostreamIT_T0_ES7_RKNSt7__cxx1112basic_stringIS4_S5_T1_EE@PLT
+	movq	_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_@GOTPCREL(%rip), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSolsEPFRSoS_E@PLT
+.LEHE10:
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	leaq	-192(%rbp), %rax
+	movq	%rax, %rdi
+.LEHB11:
+	call	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEppIL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEENSR_9return_t_INSt9enable_ifIXaaL_ZNS_6detail15has_cursor_nextISO_EEEclT_tlST_EEEvE4typeEE6invokeIRSP_EEv
+.L67:
+	leaq	-176(%rbp), %rdx
+	leaq	-192(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6rangesneINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEESO_Lb1ELi0EEEbRKNS_14basic_iteratorIT_EERKNSP_IT0_EE
+.LEHE11:
+	testb	%al, %al
+	jne	.L68
+	movl	$0, %ebx
+	leaq	-128(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED1Ev
+	leaq	-160(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev
+	leaq	-96(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movl	%ebx, %eax
+	movq	-24(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L75
+	jmp	.L81
+.L77:
+	endbr64
+	movq	%rax, %rbx
+	leaq	-128(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev
+	jmp	.L71
+.L80:
+	endbr64
+	movq	%rax, %rbx
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	jmp	.L73
+.L79:
+	endbr64
+	movq	%rax, %rbx
+.L73:
+	leaq	-128(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_ED1Ev
+	jmp	.L74
+.L78:
+	endbr64
+	movq	%rax, %rbx
+.L74:
+	leaq	-160(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev
+	jmp	.L71
+.L76:
+	endbr64
+	movq	%rax, %rbx
+.L71:
+	leaq	-96(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB12:
+	call	_Unwind_Resume@PLT
+.LEHE12:
+.L81:
+	call	__stack_chk_fail@PLT
+.L75:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9254:
+	.section	.gcc_except_table
+.LLSDA9254:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9254-.LLSDACSB9254
+.LLSDACSB9254:
+	.uleb128 .LEHB6-.LFB9254
+	.uleb128 .LEHE6-.LEHB6
+	.uleb128 .L76-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB7-.LFB9254
+	.uleb128 .LEHE7-.LEHB7
+	.uleb128 .L77-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB8-.LFB9254
+	.uleb128 .LEHE8-.LEHB8
+	.uleb128 .L78-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB9-.LFB9254
+	.uleb128 .LEHE9-.LEHB9
+	.uleb128 .L79-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB10-.LFB9254
+	.uleb128 .LEHE10-.LEHB10
+	.uleb128 .L80-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB11-.LFB9254
+	.uleb128 .LEHE11-.LEHB11
+	.uleb128 .L79-.LFB9254
+	.uleb128 0
+	.uleb128 .LEHB12-.LFB9254
+	.uleb128 .LEHE12-.LEHB12
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE9254:
+	.text
+	.size	main, .-main
+	.section	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev,"axG",@progbits,_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD5Ev,comdat
+	.align 2
+	.weak	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev
+	.type	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev, @function
+_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev:
+.LFB9476:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaIcED2Ev@PLT
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9476:
+	.size	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev, .-_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev
+	.weak	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD1Ev
+	.set	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD1Ev,_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD2Ev
+	.section	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_,"axG",@progbits,_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC5IS3_EEmcRKS3_,comdat
+	.align 2
+	.weak	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_
+	.type	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_, @function
+_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_:
+.LFB9478:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9478
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movl	%edx, %eax
+	movq	%rcx, -48(%rbp)
+	movb	%al, -36(%rbp)
+	movq	-24(%rbp), %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+.LEHB13:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv@PLT
+	movq	%rax, %rcx
+	movq	-48(%rbp), %rax
+	movq	%rax, %rdx
+	movq	%rcx, %rsi
+	movq	%rbx, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderC1EPcRKS3_@PLT
+.LEHE13:
+	movsbl	-36(%rbp), %edx
+	movq	-32(%rbp), %rcx
+	movq	-24(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+.LEHB14:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc@PLT
+.LEHE14:
+	jmp	.L86
+.L85:
+	endbr64
+	movq	%rax, %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderD1Ev
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB15:
+	call	_Unwind_Resume@PLT
+.LEHE15:
+.L86:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9478:
+	.section	.gcc_except_table
+.LLSDA9478:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9478-.LLSDACSB9478
+.LLSDACSB9478:
+	.uleb128 .LEHB13-.LFB9478
+	.uleb128 .LEHE13-.LEHB13
+	.uleb128 0
+	.uleb128 0
+	.uleb128 .LEHB14-.LFB9478
+	.uleb128 .LEHE14-.LEHB14
+	.uleb128 .L85-.LFB9478
+	.uleb128 0
+	.uleb128 .LEHB15-.LFB9478
+	.uleb128 .LEHE15-.LEHB15
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE9478:
+	.section	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_,"axG",@progbits,_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC5IS3_EEmcRKS3_,comdat
+	.size	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_, .-_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_
+	.weak	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1IS3_EEmcRKS3_
+	.set	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1IS3_EEmcRKS3_,_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEmcRKS3_
+	.weak	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits
+	.section	.rodata._ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits,"aG",@progbits,_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits,comdat
+	.align 32
+	.type	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits, @gnu_unique_object
+	.size	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits, 201
+_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits:
+	.string	"00010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899"
+	.section	.text._ZNSt8__detail18__to_chars_10_implIjEEvPcjT_,"axG",@progbits,_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_,comdat
+	.weak	_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_
+	.type	_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_, @function
+_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_:
+.LFB9484:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -24(%rbp)
+	movl	%esi, -28(%rbp)
+	movl	%edx, -32(%rbp)
+	movl	-28(%rbp), %eax
+	subl	$1, %eax
+	movl	%eax, -12(%rbp)
+	jmp	.L88
+.L89:
+	movl	-32(%rbp), %edx
+	movl	%edx, %eax
+	imulq	$1374389535, %rax, %rax
+	shrq	$32, %rax
+	shrl	$5, %eax
+	imull	$100, %eax, %ecx
+	movl	%edx, %eax
+	subl	%ecx, %eax
+	addl	%eax, %eax
+	movl	%eax, -4(%rbp)
+	movl	-32(%rbp), %eax
+	movl	%eax, %eax
+	imulq	$1374389535, %rax, %rax
+	shrq	$32, %rax
+	shrl	$5, %eax
+	movl	%eax, -32(%rbp)
+	movl	-4(%rbp), %eax
+	leal	1(%rax), %ecx
+	movl	-12(%rbp), %edx
+	movq	-24(%rbp), %rax
+	addq	%rax, %rdx
+	movl	%ecx, %ecx
+	leaq	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits(%rip), %rax
+	movzbl	(%rcx,%rax), %eax
+	movb	%al, (%rdx)
+	movl	-12(%rbp), %eax
+	subl	$1, %eax
+	movl	%eax, %edx
+	movq	-24(%rbp), %rax
+	addq	%rax, %rdx
+	movl	-4(%rbp), %eax
+	leaq	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits(%rip), %rcx
+	movzbl	(%rax,%rcx), %eax
+	movb	%al, (%rdx)
+	subl	$2, -12(%rbp)
+.L88:
+	cmpl	$99, -32(%rbp)
+	ja	.L89
+	cmpl	$9, -32(%rbp)
+	jbe	.L90
+	movl	-32(%rbp), %eax
+	addl	%eax, %eax
+	movl	%eax, -8(%rbp)
+	movl	-8(%rbp), %eax
+	leal	1(%rax), %ecx
+	movq	-24(%rbp), %rax
+	leaq	1(%rax), %rdx
+	movl	%ecx, %ecx
+	leaq	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits(%rip), %rax
+	movzbl	(%rcx,%rax), %eax
+	movb	%al, (%rdx)
+	movl	-8(%rbp), %eax
+	leaq	_ZZNSt8__detail18__to_chars_10_implIjEEvPcjT_E8__digits(%rip), %rdx
+	movzbl	(%rax,%rdx), %edx
+	movq	-24(%rbp), %rax
+	movb	%dl, (%rax)
+	jmp	.L92
+.L90:
+	movl	-32(%rbp), %eax
+	addl	$48, %eax
+	movl	%eax, %edx
+	movq	-24(%rbp), %rax
+	movb	%dl, (%rax)
+.L92:
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9484:
+	.size	_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_, .-_ZNSt8__detail18__to_chars_10_implIjEEvPcjT_
+	.section	.text._ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_,"axG",@progbits,_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_,comdat
+	.weak	_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_
+	.type	_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_, @function
+_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_:
+.LFB9701:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv
+	movq	(%rax), %rbx
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv
+	movq	(%rax), %rax
+	cmpq	%rax, %rbx
+	setne	%al
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9701:
+	.size	_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_, .-_ZN9__gnu_cxxneIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_
+	.section	.text._ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv,"axG",@progbits,_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv
+	.type	_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv, @function
+_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv:
+.LFB9702:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	leaq	1(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, (%rax)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9702:
+	.size	_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv, .-_ZN9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEppEv
+	.section	.text._ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv,"axG",@progbits,_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv
+	.type	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv, @function
+_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv:
+.LFB9703:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9703:
+	.size	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv, .-_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv
+	.section	.text._ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev,"axG",@progbits,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC5Ev,comdat
+	.align 2
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.type	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev, @function
+_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev:
+.LFB9708:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9708:
+	.size	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev, .-_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1Ev
+	.set	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1Ev,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.section	.text._ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev,"axG",@progbits,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED5Ev,comdat
+	.align 2
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.type	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev, @function
+_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev:
+.LFB9711:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9711:
+	.size	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev, .-_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev
+	.set	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC5EmRKS5_RKS6_,comdat
+	.align 2
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_:
+.LFB9714:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9714
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%rcx, -48(%rbp)
+	movq	-24(%rbp), %rbx
+	movq	-48(%rbp), %rdx
+	movq	-32(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB16:
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_
+	movq	%rax, %rcx
+	movq	-48(%rbp), %rax
+	movq	%rax, %rdx
+	movq	%rcx, %rsi
+	movq	%rbx, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_
+.LEHE16:
+	movq	-40(%rbp), %rdx
+	movq	-32(%rbp), %rcx
+	movq	-24(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+.LEHB17:
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_
+.LEHE17:
+	jmp	.L104
+.L103:
+	endbr64
+	movq	%rax, %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB18:
+	call	_Unwind_Resume@PLT
+.LEHE18:
+.L104:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9714:
+	.section	.gcc_except_table
+.LLSDA9714:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9714-.LLSDACSB9714
+.LLSDACSB9714:
+	.uleb128 .LEHB16-.LFB9714
+	.uleb128 .LEHE16-.LEHB16
+	.uleb128 0
+	.uleb128 0
+	.uleb128 .LEHB17-.LFB9714
+	.uleb128 .LEHE17-.LEHB17
+	.uleb128 .L103-.LFB9714
+	.uleb128 0
+	.uleb128 .LEHB18-.LFB9714
+	.uleb128 .LEHE18-.LEHB18
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE9714:
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC5EmRKS5_RKS6_,comdat
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1EmRKS5_RKS6_
+	.set	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1EmRKS5_RKS6_,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS5_RKS6_
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED5Ev,comdat
+	.align 2
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev:
+.LFB9717:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9717
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv
+	movq	%rax, %rdx
+	movq	-8(%rbp), %rax
+	movq	8(%rax), %rcx
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9717:
+	.section	.gcc_except_table
+.LLSDA9717:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9717-.LLSDACSB9717
+.LLSDACSB9717:
+.LLSDACSE9717:
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED5Ev,comdat
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev
+	.set	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.text
+	.type	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_, @function
+_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_:
+.LFB9720:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9720:
+	.size	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_, .-_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_
+	.align 2
+	.type	_ZNK6ranges12bind_back_fnclINS_5views17transform_base_fnEZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JEEENS_6detail13bind_back_fn_INSt5decayIT_E4typeEJNSD_IT0_E4typeEDpNSD_IT1_E4typeEEEEOSE_OSH_DpOSK_, @function
+_ZNK6ranges12bind_back_fnclINS_5views17transform_base_fnEZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JEEENS_6detail13bind_back_fn_INSt5decayIT_E4typeEJNSD_IT0_E4typeEDpNSD_IT1_E4typeEEEEOSE_OSH_DpOSK_:
+.LFB9721:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9721:
+	.size	_ZNK6ranges12bind_back_fnclINS_5views17transform_base_fnEZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JEEENS_6detail13bind_back_fn_INSt5decayIT_E4typeEJNSD_IT0_E4typeEDpNSD_IT1_E4typeEEEEOSE_OSH_DpOSK_, .-_ZNK6ranges12bind_back_fnclINS_5views17transform_base_fnEZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JEEENS_6detail13bind_back_fn_INSt5decayIT_E4typeEJNSD_IT0_E4typeEDpNSD_IT1_E4typeEEEEOSE_OSH_DpOSK_
+	.align 2
+	.type	_ZNK6ranges20make_view_closure_fnclINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEENS4_12view_closureIT_EESF_, @function
+_ZNK6ranges20make_view_closure_fnclINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEENS4_12view_closureIT_EESF_:
+.LFB9722:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	leaq	-26(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC1ESC_
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L112
+	call	__stack_chk_fail@PLT
+.L112:
+	movl	%ebx, %eax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9722:
+	.size	_ZNK6ranges20make_view_closure_fnclINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEENS4_12view_closureIT_EESF_, .-_ZNK6ranges20make_view_closure_fnclINS_6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEENS4_12view_closureIT_EESF_
+	.section	.text._ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_,"axG",@progbits,_ZN6ranges6detail8ignore_tC5ISt17integral_constantIbLb1EEEEOT_,comdat
+	.align 2
+	.weak	_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_
+	.type	_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_, @function
+_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_:
+.LFB9724:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9724:
+	.size	_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_, .-_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_
+	.weak	_ZN6ranges6detail8ignore_tC1ISt17integral_constantIbLb1EEEEOT_
+	.set	_ZN6ranges6detail8ignore_tC1ISt17integral_constantIbLb1EEEEOT_,_ZN6ranges6detail8ignore_tC2ISt17integral_constantIbLb1EEEEOT_
+	.section	.text._ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_,"axG",@progbits,_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_,comdat
+	.align 2
+	.weak	_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_
+	.type	_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_, @function
+_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_:
+.LFB9726:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rdx
+	leaq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC1ERS9_
+	movq	-16(%rbp), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L116
+	call	__stack_chk_fail@PLT
+.L116:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9726:
+	.size	_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_, .-_ZNK6ranges5views6ref_fnclISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0EEENS_8ref_viewIT_EERSD_
+	.section	.text._ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_,"axG",@progbits,_ZN6ranges6detail8ignore_tC5ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_,comdat
+	.align 2
+	.weak	_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_
+	.type	_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_, @function
+_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_:
+.LFB9728:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9728:
+	.size	_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_, .-_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_
+	.weak	_ZN6ranges6detail8ignore_tC1ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_
+	.set	_ZN6ranges6detail8ignore_tC1ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_,_ZN6ranges6detail8ignore_tC2ISt19is_lvalue_referenceINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEEEEEOT_
+	.text
+	.align 2
+	.type	_ZNO6ranges6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEclIJRSt6vectorIS9_SaIS9_EEEEEDTclL_ZNS_6invokeEEcl7declvalIS3_EEspcl7declvalIT_EEcl7declvalISA_EEEEDpOSH_, @function
+_ZNO6ranges6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEclIJRSt6vectorIS9_SaIS9_EEEEEDTclL_ZNS_6invokeEEcl7declvalIS3_EEspcl7declvalIT_EEcl7declvalISA_EEEEDpOSH_:
+.LFB9731:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rax
+	leaq	1(%rax), %rsi
+	movq	-32(%rbp), %rdx
+	movq	-24(%rbp), %rax
+	movq	-40(%rbp), %rcx
+	movq	%rsi, %r8
+	leaq	_ZN6ranges6invokeE(%rip), %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges9invoke_fnclINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEZ4mainEUlSA_E_EEEDTclcvOT_fp_spcvOT0_fp0_EESG_DpSI_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L120
+	call	__stack_chk_fail@PLT
+.L120:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9731:
+	.size	_ZNO6ranges6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEclIJRSt6vectorIS9_SaIS9_EEEEEDTclL_ZNS_6invokeEEcl7declvalIS3_EEspcl7declvalIT_EEcl7declvalISA_EEEEDpOSH_, .-_ZNO6ranges6detail13bind_back_fn_INS_5views17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEclIJRSt6vectorIS9_SaIS9_EEEEEDTclL_ZNS_6invokeEEcl7declvalIS3_EEspcl7declvalIT_EEcl7declvalISA_EEEEDpOSH_
+	.align 2
+	.type	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED2Ev, @function
+_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED2Ev:
+.LFB9733:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEE5resetEv
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9733:
+	.size	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED2Ev, .-_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED2Ev
+	.set	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED1Ev,_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEED2Ev
+	.align 2
+	.type	_ZNK6ranges9invoke_fnclIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESL_DpSN_, @function
+_ZNK6ranges9invoke_fnclIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESL_DpSN_:
+.LFB9737:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%rcx, -48(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-48(%rbp), %rdx
+	movq	-40(%rbp), %rcx
+	movq	(%rdx), %rdx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EclIJN9__gnu_cxx17__normal_iteratorIPS6_St6vectorIS6_SaIS6_EEEEEEEDTclL_ZNS_6invokeEEdtdefpT3fn_spdefp_EEDpT_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L124
+	call	__stack_chk_fail@PLT
+.L124:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9737:
+	.size	_ZNK6ranges9invoke_fnclIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESL_DpSN_, .-_ZNK6ranges9invoke_fnclIRNS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESL_DpSN_
+	.align 2
+	.type	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE5beginISG_Lb1ELi0EEENS_14basic_iteratorINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeEEEv, @function
+_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE5beginISG_Lb1ELi0EEENS_14basic_iteratorINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeEEEv:
+.LFB9739:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$64, %rsp
+	movq	%rdi, -56(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-56(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access12begin_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_12begin_cursorEERT_
+	movq	%rax, -48(%rbp)
+	movq	%rdx, -40(%rbp)
+	leaq	-48(%rbp), %rdx
+	leaq	-32(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC1EOSO_
+	movq	-32(%rbp), %rax
+	movq	-24(%rbp), %rdx
+	movq	-8(%rbp), %rcx
+	subq	%fs:40, %rcx
+	je	.L127
+	call	__stack_chk_fail@PLT
+.L127:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9739:
+	.size	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE5beginISG_Lb1ELi0EEENS_14basic_iteratorINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeEEEv, .-_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE5beginISG_Lb1ELi0EEENS_14basic_iteratorINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeEEEv
+	.align 2
+	.type	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE3endISG_Lb1ELi0EEEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbX7same_asINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeENSP_IDTclsrSQ_10end_cursorcl7declvalISS_EEEEE4typeEEEENS_14basic_iteratorISV_EESY_EEESO_IbLb1EEE4typeEv, @function
+_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE3endISG_Lb1ELi0EEEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbX7same_asINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeENSP_IDTclsrSQ_10end_cursorcl7declvalISS_EEEEE4typeEEEENS_14basic_iteratorISV_EESY_EEESO_IbLb1EEE4typeEv:
+.LFB9740:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$64, %rsp
+	movq	%rdi, -56(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-56(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access10end_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_10end_cursorEERT_
+	movq	%rax, -48(%rbp)
+	movq	%rdx, -40(%rbp)
+	leaq	-48(%rbp), %rdx
+	leaq	-32(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC1EOSO_
+	movq	-32(%rbp), %rax
+	movq	-24(%rbp), %rdx
+	movq	-8(%rbp), %rcx
+	subq	%fs:40, %rcx
+	je	.L130
+	call	__stack_chk_fail@PLT
+.L130:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9740:
+	.size	_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE3endISG_Lb1ELi0EEEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbX7same_asINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeENSP_IDTclsrSQ_10end_cursorcl7declvalISS_EEEEE4typeEEEENS_14basic_iteratorISV_EESY_EEESO_IbLb1EEE4typeEv, .-_ZN6ranges11view_facadeINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE3endISG_Lb1ELi0EEEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbX7same_asINSt5decayIDTclsrNS_12range_accessE12begin_cursorcl7declvalIRT_EEEEE4typeENSP_IDTclsrSQ_10end_cursorcl7declvalISS_EEEEE4typeEEEENS_14basic_iteratorISV_EESY_EEESO_IbLb1EEE4typeEv
+	.type	_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE, @function
+_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE:
+.LFB9741:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9741:
+	.size	_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE, .-_ZN6ranges12range_access3posINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEERKT_RKNS_14basic_iteratorISQ_EE
+	.align 2
+	.type	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5equalISN_EEDTcldtcl7declvalIRKT_EE6equal_fp_Li42EEERKSN_, @function
+_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5equalISN_EEDTcldtcl7declvalIRKT_EE6equal_fp_Li42EEERKSN_:
+.LFB9742:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rcx
+	movq	-8(%rbp), %rax
+	movl	$42, %edx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6equal_ISM_bEEbRKSN_l
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9742:
+	.size	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5equalISN_EEDTcldtcl7declvalIRKT_EE6equal_fp_Li42EEERKSN_, .-_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5equalISN_EEDTcldtcl7declvalIRKT_EE6equal_fp_Li42EEERKSN_
+	.align 2
+	.type	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv, @function
+_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv:
+.LFB9743:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9743:
+	.size	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv, .-_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv
+	.type	_ZN6ranges12range_access4nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4nextEERT_, @function
+_ZN6ranges12range_access4nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4nextEERT_:
+.LFB9744:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4nextISM_vEEvv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9744:
+	.size	_ZN6ranges12range_access4nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4nextEERT_, .-_ZN6ranges12range_access4nextINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4nextEERT_
+	.align 2
+	.type	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv, @function
+_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv:
+.LFB9745:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9745:
+	.size	_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv, .-_ZNK6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEE3posEv
+	.type	_ZN6ranges12range_access4readINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4readEERKT_, @function
+_ZN6ranges12range_access4readINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4readEERKT_:
+.LFB9746:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-32(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4readISM_S8_EET0_v
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L143
+	call	__stack_chk_fail@PLT
+.L143:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9746:
+	.size	_ZN6ranges12range_access4readINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4readEERKT_, .-_ZN6ranges12range_access4readINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEDTcldtfp_4readEERKT_
+	.section	.text._ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv,"axG",@progbits,_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv
+	.type	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv, @function
+_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv:
+.LFB9922:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9922:
+	.size	_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv, .-_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE4baseEv
+	.section	.text._ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev,"axG",@progbits,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC5Ev,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.type	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev, @function
+_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev:
+.LFB9925:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9925:
+	.size	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev, .-_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1Ev
+	.set	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1Ev,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2Ev
+	.section	.text._ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev,"axG",@progbits,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED5Ev,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.type	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev, @function
+_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev:
+.LFB9928:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9928:
+	.size	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev, .-_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev
+	.set	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	.section	.rodata
+	.align 8
+.LC5:
+	.string	"cannot create std::vector larger than max_size()"
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_,comdat
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_:
+.LFB9930:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%rsi, -48(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movq	-48(%rbp), %rdx
+	leaq	-25(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1ERKS5_
+	leaq	-25(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_
+	cmpq	%rax, -40(%rbp)
+	seta	%bl
+	leaq	-25(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED1Ev
+	testb	%bl, %bl
+	je	.L149
+	leaq	.LC5(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZSt20__throw_length_errorPKc@PLT
+.L149:
+	movq	-40(%rbp), %rax
+	movq	-24(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L151
+	call	__stack_chk_fail@PLT
+.L151:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9930:
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_S_check_init_lenEmRKS6_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD5Ev,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev:
+.LFB9933:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEED2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9933:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD1Ev
+	.set	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD1Ev,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD2Ev
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC5EmRKS6_,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_:
+.LFB9935:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9935
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	-24(%rbp), %rax
+	movq	-40(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC1ERKS6_
+	movq	-32(%rbp), %rdx
+	movq	-24(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB19:
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm
+.LEHE19:
+	jmp	.L156
+.L155:
+	endbr64
+	movq	%rax, %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD1Ev
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB20:
+	call	_Unwind_Resume@PLT
+.LEHE20:
+.L156:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9935:
+	.section	.gcc_except_table
+.LLSDA9935:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9935-.LLSDACSB9935
+.LLSDACSB9935:
+	.uleb128 .LEHB19-.LFB9935
+	.uleb128 .LEHE19-.LEHB19
+	.uleb128 .L155-.LFB9935
+	.uleb128 0
+	.uleb128 .LEHB20-.LFB9935
+	.uleb128 .LEHE20-.LEHB20
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE9935:
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC5EmRKS6_,comdat
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1EmRKS6_
+	.set	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1EmRKS6_,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC2EmRKS6_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED5Ev,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev:
+.LFB9938:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA9938
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	16(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rcx
+	movq	%rdx, %rax
+	subq	%rcx, %rax
+	sarq	$5, %rax
+	movq	%rax, %rdx
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rcx
+	movq	-8(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implD1Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9938:
+	.section	.gcc_except_table
+.LLSDA9938:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE9938-.LLSDACSB9938
+.LLSDACSB9938:
+.LLSDACSE9938:
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED5Ev,comdat
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev
+	.set	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED2Ev
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_,comdat
+	.align 2
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_:
+.LFB9940:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv
+	movq	%rax, %rcx
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	movq	-24(%rbp), %rdx
+	movq	-16(%rbp), %rsi
+	movq	%rax, %rdi
+	call	_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E
+	movq	-8(%rbp), %rdx
+	movq	%rax, 8(%rdx)
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9940:
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE18_M_fill_initializeEmRKS5_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv:
+.LFB9941:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9941:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE19_M_get_Tp_allocatorEv
+	.section	.text._ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E,"axG",@progbits,_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E,comdat
+	.weak	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E
+	.type	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E, @function
+_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E:
+.LFB9942:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9942:
+	.size	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E, .-_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_EvT_S7_RSaIT0_E
+	.text
+	.align 2
+	.type	_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC2ESC_, @function
+_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC2ESC_:
+.LFB9944:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9944:
+	.size	_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC2ESC_, .-_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC2ESC_
+	.set	_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC1ESC_,_ZN6ranges5views12view_closureINS_6detail13bind_back_fn_INS0_17transform_base_fnEJZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEC2ESC_
+	.section	.text._ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_,"axG",@progbits,_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC5ERS9_,comdat
+	.align 2
+	.weak	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_
+	.type	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_, @function
+_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_:
+.LFB9947:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	movq	-8(%rbp), %rdx
+	movq	%rax, (%rdx)
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9947:
+	.size	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_, .-_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_
+	.weak	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC1ERS9_
+	.set	_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC1ERS9_,_ZN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEEC2ERS9_
+	.text
+	.align 2
+	.type	_ZNK6ranges9invoke_fnclINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEZ4mainEUlSA_E_EEEDTclcvOT_fp_spcvOT0_fp0_EESG_DpSI_, @function
+_ZNK6ranges9invoke_fnclINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEZ4mainEUlSA_E_EEEDTclcvOT_fp_spcvOT0_fp0_EESG_DpSI_:
+.LFB9950:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$64, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%rcx, -48(%rbp)
+	movq	%r8, -56(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-48(%rbp), %rdx
+	movq	-40(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges5views17transform_base_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_Lb1ELi0EEENS_14transform_viewIDTclL_ZNS0_3allEEcl7declvalIT_EEEET0_EEOSF_SH_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L166
+	call	__stack_chk_fail@PLT
+.L166:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9950:
+	.size	_ZNK6ranges9invoke_fnclINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEZ4mainEUlSA_E_EEEDTclcvOT_fp_spcvOT0_fp0_EESG_DpSI_, .-_ZNK6ranges9invoke_fnclINS_5views17transform_base_fnEJRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEZ4mainEUlSA_E_EEEDTclcvOT_fp_spcvOT0_fp0_EESG_DpSI_
+	.align 2
+	.type	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEE5resetEv, @function
+_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEE5resetEv:
+.LFB9951:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movzbl	1(%rax), %eax
+	testb	%al, %al
+	je	.L169
+	movq	-8(%rbp), %rax
+	movb	$0, 1(%rax)
+.L169:
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9951:
+	.size	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEE5resetEv, .-_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEE5resetEv
+	.align 2
+	.type	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EclIJN9__gnu_cxx17__normal_iteratorIPS6_St6vectorIS6_SaIS6_EEEEEEEDTclL_ZNS_6invokeEEdtdefpT3fn_spdefp_EEDpT_, @function
+_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EclIJN9__gnu_cxx17__normal_iteratorIPS6_St6vectorIS6_SaIS6_EEEEEEEDTclL_ZNS_6invokeEEdtdefpT3fn_spdefp_EEDpT_:
+.LFB9954:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	leaq	-40(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv
+	movq	%rax, %rcx
+	movq	-32(%rbp), %rdx
+	movq	-24(%rbp), %rax
+	leaq	_ZN6ranges6invokeE(%rip), %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges9invoke_fnclIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS7_EEEDTclcvOT_fp_spcvOT0_fp0_EESC_DpSE_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L172
+	call	__stack_chk_fail@PLT
+.L172:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9954:
+	.size	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EclIJN9__gnu_cxx17__normal_iteratorIPS6_St6vectorIS6_SaIS6_EEEEEEEDTclL_ZNS_6invokeEEdtdefpT3fn_spdefp_EEDpT_, .-_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EclIJN9__gnu_cxx17__normal_iteratorIPS6_St6vectorIS6_SaIS6_EEEEEEEDTclL_ZNS_6invokeEEdtdefpT3fn_spdefp_EEDpT_
+	.type	_ZN6ranges12range_access12begin_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_12begin_cursorEERT_, @function
+_ZN6ranges12range_access12begin_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_12begin_cursorEERT_:
+.LFB9956:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE12begin_cursorISG_Lb1ELi0EEEDTclsrSI_13begin_cursor_cl7declvalIRT_EEEEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9956:
+	.size	_ZN6ranges12range_access12begin_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_12begin_cursorEERT_, .-_ZN6ranges12range_access12begin_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_12begin_cursorEERT_
+	.align 2
+	.type	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2EOSO_, @function
+_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2EOSO_:
+.LFB9958:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail31iterator_associated_types_base_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEC2EOSP_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9958:
+	.size	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2EOSO_, .-_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2EOSO_
+	.set	_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC1EOSO_,_ZN6ranges14basic_iteratorINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2EOSO_
+	.type	_ZN6ranges12range_access10end_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_10end_cursorEERT_, @function
+_ZN6ranges12range_access10end_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_10end_cursorEERT_:
+.LFB9960:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE10end_cursorISG_Lb1ELi0EEEDTclsrSI_11end_cursor_cl7declvalIRT_EEEEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9960:
+	.size	_ZN6ranges12range_access10end_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_10end_cursorEERT_, .-_ZN6ranges12range_access10end_cursorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_10end_cursorEERT_
+	.align 2
+	.type	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6equal_ISM_bEEbRKSN_l, @function
+_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6equal_ISM_bEEbRKSN_l:
+.LFB9961:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	movq	%rax, %rbx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9961:
+	.size	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6equal_ISM_bEEbRKSN_l, .-_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6equal_ISM_bEEbRKSN_l
+	.align 2
+	.type	_ZNR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv, @function
+_ZNR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv:
+.LFB9962:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9962:
+	.size	_ZNR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv, .-_ZNR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv
+	.align 2
+	.type	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4nextISM_vEEvv, @function
+_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4nextISM_vEEvv:
+.LFB9963:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	movq	%rax, %rdi
+	call	_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9963:
+	.size	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4nextISM_vEEvv, .-_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4nextISM_vEEvv
+	.align 2
+	.type	_ZNKR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv, @function
+_ZNKR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv:
+.LFB9964:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9964:
+	.size	_ZNKR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv, .-_ZNKR6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EE3getEv
+	.align 2
+	.type	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4readISM_S8_EET0_v, @function
+_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4readISM_S8_EET0_v:
+.LFB9965:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%rsi, -48(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movq	-48(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv
+	movq	%rax, %rbx
+	movq	-48(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	movq	%rax, %rdx
+	movq	-40(%rbp), %rax
+	movq	(%rdx), %rdx
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EE4readEN9__gnu_cxx17__normal_iteratorIPS8_SA_EE
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L187
+	call	__stack_chk_fail@PLT
+.L187:
+	movq	-40(%rbp), %rax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE9965:
+	.size	_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4readISM_S8_EET0_v, .-_ZNK6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE4readISM_S8_EET0_v
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_,comdat
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_:
+.LFB10055:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movabsq	$288230376151711743, %rax
+	movq	%rax, -24(%rbp)
+	movq	-40(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_
+	movq	%rax, -16(%rbp)
+	leaq	-16(%rbp), %rdx
+	leaq	-24(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZSt3minImERKT_S2_S2_
+	movq	(%rax), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L190
+	call	__stack_chk_fail@PLT
+.L190:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10055:
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_S_max_sizeERKS6_
+	.section	.text._ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_,"axG",@progbits,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC5ERKS5_,comdat
+	.align 2
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_
+	.type	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_, @function
+_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_:
+.LFB10057:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10057:
+	.size	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_, .-_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_
+	.weak	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1ERKS5_
+	.set	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1ERKS5_,_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC5ERKS6_,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_:
+.LFB10060:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS5_
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10060:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC1ERKS6_
+	.set	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC1ERKS6_,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE12_Vector_implC2ERKS6_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm:
+.LFB10062:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm
+	movq	-8(%rbp), %rdx
+	movq	%rax, (%rdx)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, 8(%rax)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rdx
+	movq	-16(%rbp), %rax
+	salq	$5, %rax
+	addq	%rax, %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, 16(%rax)
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10062:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_create_storageEm
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m:
+.LFB10063:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	cmpq	$0, -16(%rbp)
+	je	.L196
+	movq	-8(%rbp), %rax
+	movq	-24(%rbp), %rdx
+	movq	-16(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m
+.L196:
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10063:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE13_M_deallocateEPS5_m
+	.section	.text._ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E,"axG",@progbits,_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E,comdat
+	.weak	_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E
+	.type	_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E, @function
+_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E:
+.LFB10064:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	%rcx, -32(%rbp)
+	movq	-24(%rbp), %rdx
+	movq	-16(%rbp), %rcx
+	movq	-8(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10064:
+	.size	_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E, .-_ZSt24__uninitialized_fill_n_aIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_S5_ET_S7_T0_RKT1_RSaIT2_E
+	.section	.text._ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_,"axG",@progbits,_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_,comdat
+	.weak	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_
+	.type	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_, @function
+_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_:
+.LFB10065:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10065:
+	.size	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_, .-_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_
+	.section	.text._ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_,"axG",@progbits,_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_,comdat
+	.weak	_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	.type	_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_, @function
+_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_:
+.LFB10066:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10066:
+	.size	_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_, .-_ZSt9addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	.text
+	.align 2
+	.type	_ZNK6ranges5views17transform_base_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_Lb1ELi0EEENS_14transform_viewIDTclL_ZNS0_3allEEcl7declvalIT_EEEET0_EEOSF_SH_, @function
+_ZNK6ranges5views17transform_base_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_Lb1ELi0EEENS_14transform_viewIDTclL_ZNS0_3allEEcl7declvalIT_EEEET0_EEOSF_SH_:
+.LFB10067:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	-40(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges5views3allE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges5views6all_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEDaOT_
+	movq	%rax, %rbx
+	leaq	-41(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_
+	movq	-24(%rbp), %rax
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC1ESB_SC_
+	movq	-24(%rbp), %rax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10067:
+	.size	_ZNK6ranges5views17transform_base_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_Lb1ELi0EEENS_14transform_viewIDTclL_ZNS0_3allEEcl7declvalIT_EEEET0_EEOSF_SH_, .-_ZNK6ranges5views17transform_base_fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEZ4mainEUlS9_E_Lb1ELi0EEENS_14transform_viewIDTclL_ZNS0_3allEEcl7declvalIT_EEEET0_EEOSF_SH_
+	.section	.text._ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv,"axG",@progbits,_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv
+	.type	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv, @function
+_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv:
+.LFB10068:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10068:
+	.size	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv, .-_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEdeEv
+	.text
+	.align 2
+	.type	_ZNK6ranges9invoke_fnclIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS7_EEEDTclcvOT_fp_spcvOT0_fp0_EESC_DpSE_, @function
+_ZNK6ranges9invoke_fnclIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS7_EEEDTclcvOT_fp_spcvOT0_fp0_EESC_DpSE_:
+.LFB10071:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA10071
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$88, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -72(%rbp)
+	movq	%rsi, -80(%rbp)
+	movq	%rdx, -88(%rbp)
+	movq	%rcx, -96(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movq	-96(%rbp), %rdx
+	leaq	-64(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB21:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_@PLT
+.LEHE21:
+	movq	-72(%rbp), %rax
+	leaq	-64(%rbp), %rdx
+	movq	-88(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+.LEHB22:
+	call	_ZZ4mainENKUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_clES4_
+.LEHE22:
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L209
+	jmp	.L211
+.L210:
+	endbr64
+	movq	%rax, %rbx
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB23:
+	call	_Unwind_Resume@PLT
+.LEHE23:
+.L211:
+	call	__stack_chk_fail@PLT
+.L209:
+	movq	-72(%rbp), %rax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10071:
+	.section	.gcc_except_table
+.LLSDA10071:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE10071-.LLSDACSB10071
+.LLSDACSB10071:
+	.uleb128 .LEHB21-.LFB10071
+	.uleb128 .LEHE21-.LEHB21
+	.uleb128 0
+	.uleb128 0
+	.uleb128 .LEHB22-.LFB10071
+	.uleb128 .LEHE22-.LEHB22
+	.uleb128 .L210-.LFB10071
+	.uleb128 0
+	.uleb128 .LEHB23-.LFB10071
+	.uleb128 .LEHE23-.LEHB23
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE10071:
+	.text
+	.size	_ZNK6ranges9invoke_fnclIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS7_EEEDTclcvOT_fp_spcvOT0_fp0_EESC_DpSE_, .-_ZNK6ranges9invoke_fnclIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_JRS7_EEEDTclcvOT_fp_spcvOT0_fp0_EESC_DpSE_
+	.align 2
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE12begin_cursorISG_Lb1ELi0EEEDTclsrSI_13begin_cursor_cl7declvalIRT_EEEEv, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE12begin_cursorISG_Lb1ELi0EEEDTclsrSI_13begin_cursor_cl7declvalIRT_EEEEv:
+.LFB10072:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE13begin_cursor_ISG_EENS_14adaptor_cursorINSt5decayIDTcldtcl7declvalINSL_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISO_EEEEE4typeESR_EESO_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10072:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE12begin_cursorISG_Lb1ELi0EEEDTclsrSI_13begin_cursor_cl7declvalIRT_EEEEv, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE12begin_cursorISG_Lb1ELi0EEEDTclsrSI_13begin_cursor_cl7declvalIRT_EEEEv
+	.align 2
+	.type	_ZN6ranges6detail31iterator_associated_types_base_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEC2EOSP_, @function
+_ZN6ranges6detail31iterator_associated_types_base_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEC2EOSP_:
+.LFB10074:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail39readable_iterator_associated_types_baseINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEvEC2EOSP_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10074:
+	.size	_ZN6ranges6detail31iterator_associated_types_base_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEC2EOSP_, .-_ZN6ranges6detail31iterator_associated_types_base_INS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEELb1EEC2EOSP_
+	.align 2
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE10end_cursorISG_Lb1ELi0EEEDTclsrSI_11end_cursor_cl7declvalIRT_EEEEv, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE10end_cursorISG_Lb1ELi0EEEDTclsrSI_11end_cursor_cl7declvalIRT_EEEEv:
+.LFB10076:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE11end_cursor_ISG_EEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbXaa7same_asINSt5decayIDTcldtcl7declvalINSP_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISS_EEEEE4typeENSP_IDTcldtcl7declvalINSP_IDTclsrSQ_11end_adaptorcl7declvalISS_EEEEE4typeEEE3endcl7declvalISS_EEEEE4typeEE7same_asISV_S11_EEENS_14adaptor_cursorISY_SV_EENS_16adaptor_sentinelIS14_S11_EEEEESO_IbLb1EEE4typeESS_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10076:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE10end_cursorISG_Lb1ELi0EEEDTclsrSI_11end_cursor_cl7declvalIRT_EEEEv, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE10end_cursorISG_Lb1ELi0EEEDTclsrSI_11end_cursor_cl7declvalIRT_EEEEv
+	.align 2
+	.type	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv, @function
+_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv:
+.LFB10077:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	addq	$8, %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10077:
+	.size	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv, .-_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv
+	.align 2
+	.type	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv, @function
+_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv:
+.LFB10078:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10078:
+	.size	_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv, .-_ZNKR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	.section	.text._ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_,"axG",@progbits,_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_,comdat
+	.weak	_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_
+	.type	_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_, @function
+_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_:
+.LFB10079:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10079:
+	.size	_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_, .-_ZN6ranges12adaptor_base5equalIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEbRKT_SH_
+	.text
+	.align 2
+	.type	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv, @function
+_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv:
+.LFB10080:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	addq	$8, %rax
+	movq	%rax, %rdi
+	call	_ZNR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10080:
+	.size	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv, .-_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE6secondEv
+	.align 2
+	.type	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv, @function
+_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv:
+.LFB10081:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10081:
+	.size	_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv, .-_ZNR6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE5firstEv
+	.section	.text._ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_,"axG",@progbits,_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_,comdat
+	.weak	_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_
+	.type	_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_, @function
+_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_:
+.LFB10082:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10082:
+	.size	_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_, .-_ZN6ranges12adaptor_base4nextIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEELb1ELi0EEEvRT_
+	.text
+	.align 2
+	.type	_ZNK6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EE4readEN9__gnu_cxx17__normal_iteratorIPS8_SA_EE, @function
+_ZNK6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EE4readEN9__gnu_cxx17__normal_iteratorIPS8_SA_EE:
+.LFB10083:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rdx
+	movq	-24(%rbp), %rax
+	leaq	-40(%rbp), %rcx
+	leaq	_ZN6ranges6invokeE(%rip), %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges9invoke_fnclIRKNS_17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESQ_DpSS_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L230
+	call	__stack_chk_fail@PLT
+.L230:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10083:
+	.size	_ZNK6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EE4readEN9__gnu_cxx17__normal_iteratorIPS8_SA_EE, .-_ZNK6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EE4readEN9__gnu_cxx17__normal_iteratorIPS8_SA_EE
+	.section	.text._ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_,"axG",@progbits,_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_,comdat
+	.weak	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_
+	.type	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_, @function
+_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_:
+.LFB10143:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10143:
+	.size	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_, .-_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8max_sizeERKS6_
+	.section	.text._ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_,"axG",@progbits,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC5ERKS7_,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_
+	.type	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_, @function
+_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_:
+.LFB10145:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10145:
+	.size	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_, .-_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1ERKS7_
+	.set	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC1ERKS7_,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEC2ERKS7_
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC5Ev,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev:
+.LFB10148:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	$0, (%rax)
+	movq	-8(%rbp), %rax
+	movq	$0, 8(%rax)
+	movq	-8(%rbp), %rax
+	movq	$0, 16(%rax)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10148:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC1Ev
+	.set	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC1Ev,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_Vector_impl_dataC2Ev
+	.section	.text._ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm,"axG",@progbits,_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm,comdat
+	.align 2
+	.weak	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm
+	.type	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm, @function
+_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm:
+.LFB10150:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	cmpq	$0, -16(%rbp)
+	je	.L236
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m
+	jmp	.L238
+.L236:
+	movl	$0, %eax
+.L238:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10150:
+	.size	_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm, .-_ZNSt12_Vector_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE11_M_allocateEm
+	.section	.text._ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m,"axG",@progbits,_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m,comdat
+	.weak	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m
+	.type	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m, @function
+_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m:
+.LFB10151:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-24(%rbp), %rdx
+	movq	-16(%rbp), %rcx
+	movq	-8(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10151:
+	.size	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m, .-_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE10deallocateERS6_PS5_m
+	.section	.text._ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_,"axG",@progbits,_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_,comdat
+	.weak	_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_
+	.type	_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_, @function
+_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_:
+.LFB10152:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movb	$1, -1(%rbp)
+	movq	-40(%rbp), %rdx
+	movq	-32(%rbp), %rcx
+	movq	-24(%rbp), %rax
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10152:
+	.size	_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_, .-_ZSt20uninitialized_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS5_ET_S7_T0_RKT1_
+	.section	.text._ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_,"axG",@progbits,_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_,comdat
+	.weak	_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_
+	.type	_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_, @function
+_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_:
+.LFB10153:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	jmp	.L243
+.L244:
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_
+	movq	%rax, %rdi
+	call	_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_
+	addq	$32, -8(%rbp)
+.L243:
+	movq	-8(%rbp), %rax
+	cmpq	-16(%rbp), %rax
+	jne	.L244
+	nop
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10153:
+	.size	_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_, .-_ZNSt12_Destroy_auxILb0EE9__destroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvT_S9_
+	.section	.text._ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_,"axG",@progbits,_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_,comdat
+	.weak	_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	.type	_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_, @function
+_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_:
+.LFB10154:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10154:
+	.size	_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_, .-_ZSt11__addressofISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEEPT_RS9_
+	.text
+	.align 2
+	.type	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC2ESB_SC_, @function
+_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC2ESB_SC_:
+.LFB10156:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%r12
+	pushq	%rbx
+	subq	$32, %rsp
+	.cfi_offset 12, -24
+	.cfi_offset 3, -32
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rbx
+	leaq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_
+	movq	(%rax), %r12
+	leaq	-33(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_
+	leaq	_ZN6ranges8indirectE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges11indirect_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS_10indirectedIT_EESA_
+	movq	%r12, %rsi
+	movq	%rbx, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEEC2ESB_SE_
+	nop
+	addq	$32, %rsp
+	popq	%rbx
+	popq	%r12
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10156:
+	.size	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC2ESB_SC_, .-_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC2ESB_SC_
+	.set	_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC1ESB_SC_,_ZN6ranges14transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEZ4mainEUlS8_E_EC2ESB_SC_
+	.section	.rodata
+	.type	_ZN8concepts4defs12derived_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEENS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, @object
+	.size	_ZN8concepts4defs12derived_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEENS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, 1
+_ZN8concepts4defs12derived_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEENS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs14convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, @object
+	.size	_ZN8concepts4defs14convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, 1
+_ZN8concepts4defs14convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, 1
+_ZN8concepts4defs25implicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE, 1
+_ZN8concepts4defs25explicitly_convertible_toIPVKN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEEEPVKNS2_14view_interfaceISI_LNS2_11cardinalityEn1EEEEE:
+	.byte	1
+	.text
+	.align 2
+	.type	_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv, @function
+_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv:
+.LFB10158:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10158:
+	.size	_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv, .-_ZN6ranges14view_interfaceINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEELNS_11cardinalityEn1EE7derivedEv
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE13begin_cursor_ISG_EENS_14adaptor_cursorINSt5decayIDTcldtcl7declvalINSL_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISO_EEEEE4typeESR_EESO_, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE13begin_cursor_ISG_EENS_14adaptor_cursorINSt5decayIDTcldtcl7declvalINSL_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISO_EEEEE4typeESR_EESO_:
+.LFB10159:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$72, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -72(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movq	-72(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access13begin_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_13begin_adaptorEERT_
+	movq	%rax, -64(%rbp)
+	movq	-72(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12adaptor_base5beginINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_5beginEEcldtfp_4baseEEERT_
+	movq	%rax, -56(%rbp)
+	leaq	-56(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_
+	movq	(%rax), %rbx
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_
+	movq	%rax, %rdx
+	leaq	-48(%rbp), %rax
+	movq	(%rdx), %rdx
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC1ESD_SM_
+	movq	-48(%rbp), %rax
+	movq	-40(%rbp), %rdx
+	movq	-24(%rbp), %rcx
+	subq	%fs:40, %rcx
+	je	.L252
+	call	__stack_chk_fail@PLT
+.L252:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10159:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE13begin_cursor_ISG_EENS_14adaptor_cursorINSt5decayIDTcldtcl7declvalINSL_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISO_EEEEE4typeESR_EESO_, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE13begin_cursor_ISG_EENS_14adaptor_cursorINSt5decayIDTcldtcl7declvalINSL_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISO_EEEEE4typeESR_EESO_
+	.align 2
+	.type	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinCI2NS_11basic_mixinISN_EEIL_ZN8concepts6detail11CPP_true_fnENST_3NilEEEEOSN_NSt9enable_ifIXaaL_ZNSS_4defs18move_constructibleISN_EEEclT_tlSU_EEESU_E4typeE, @function
+_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinCI2NS_11basic_mixinISN_EEIL_ZN8concepts6detail11CPP_true_fnENST_3NilEEEEOSN_NSt9enable_ifIXaaL_ZNSS_4defs18move_constructibleISN_EEEclT_tlSU_EEESU_E4typeE:
+.LFB10162:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges11basic_mixinINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2IL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEEOSO_NSt9enable_ifIXaaL_ZNSR_4defs18move_constructibleISO_EEEclT_tlST_EEEST_E4typeE
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10162:
+	.size	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinCI2NS_11basic_mixinISN_EEIL_ZN8concepts6detail11CPP_true_fnENST_3NilEEEEOSN_NSt9enable_ifIXaaL_ZNSS_4defs18move_constructibleISN_EEEclT_tlSU_EEESU_E4typeE, .-_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinCI2NS_11basic_mixinISN_EEIL_ZN8concepts6detail11CPP_true_fnENST_3NilEEEEOSN_NSt9enable_ifIXaaL_ZNSS_4defs18move_constructibleISN_EEEclT_tlSU_EEESU_E4typeE
+	.align 2
+	.type	_ZN6ranges6detail39readable_iterator_associated_types_baseINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEvEC2EOSP_, @function
+_ZN6ranges6detail39readable_iterator_associated_types_baseINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEvEC2EOSP_:
+.LFB10164:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEE19basic_adaptor_mixinCI2NS_11basic_mixinISN_EEIL_ZN8concepts6detail11CPP_true_fnENST_3NilEEEEOSN_NSt9enable_ifIXaaL_ZNSS_4defs18move_constructibleISN_EEEclT_tlSU_EEESU_E4typeE
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10164:
+	.size	_ZN6ranges6detail39readable_iterator_associated_types_baseINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEvEC2EOSP_, .-_ZN6ranges6detail39readable_iterator_associated_types_baseINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEvEC2EOSP_
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE11end_cursor_ISG_EEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbXaa7same_asINSt5decayIDTcldtcl7declvalINSP_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISS_EEEEE4typeENSP_IDTcldtcl7declvalINSP_IDTclsrSQ_11end_adaptorcl7declvalISS_EEEEE4typeEEE3endcl7declvalISS_EEEEE4typeEE7same_asISV_S11_EEENS_14adaptor_cursorISY_SV_EENS_16adaptor_sentinelIS14_S11_EEEEESO_IbLb1EEE4typeESS_, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE11end_cursor_ISG_EEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbXaa7same_asINSt5decayIDTcldtcl7declvalINSP_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISS_EEEEE4typeENSP_IDTcldtcl7declvalINSP_IDTclsrSQ_11end_adaptorcl7declvalISS_EEEEE4typeEEE3endcl7declvalISS_EEEEE4typeEE7same_asISV_S11_EEENS_14adaptor_cursorISY_SV_EENS_16adaptor_sentinelIS14_S11_EEEEESO_IbLb1EEE4typeESS_:
+.LFB10166:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$72, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -72(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	movq	-72(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12range_access11end_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_11end_adaptorEERT_
+	movq	%rax, -64(%rbp)
+	movq	-72(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12adaptor_base3endINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_3endEEcldtfp_4baseEEERT_
+	movq	%rax, -56(%rbp)
+	leaq	-56(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_
+	movq	(%rax), %rbx
+	leaq	-64(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_
+	movq	%rax, %rdx
+	leaq	-48(%rbp), %rax
+	movq	(%rdx), %rdx
+	movq	%rbx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC1ESD_SM_
+	movq	-48(%rbp), %rax
+	movq	-40(%rbp), %rdx
+	movq	-24(%rbp), %rcx
+	subq	%fs:40, %rcx
+	je	.L257
+	call	__stack_chk_fail@PLT
+.L257:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10166:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE11end_cursor_ISG_EEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbXaa7same_asINSt5decayIDTcldtcl7declvalINSP_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISS_EEEEE4typeENSP_IDTcldtcl7declvalINSP_IDTclsrSQ_11end_adaptorcl7declvalISS_EEEEE4typeEEE3endcl7declvalISS_EEEEE4typeEE7same_asISV_S11_EEENS_14adaptor_cursorISY_SV_EENS_16adaptor_sentinelIS14_S11_EEEEESO_IbLb1EEE4typeESS_, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE11end_cursor_ISG_EEN4meta6detail4_if_INSK_4listIJSt17integral_constantIbXaa7same_asINSt5decayIDTcldtcl7declvalINSP_IDTclsrNS_12range_accessE13begin_adaptorcl7declvalIRT_EEEEE4typeEEE5begincl7declvalISS_EEEEE4typeENSP_IDTcldtcl7declvalINSP_IDTclsrSQ_11end_adaptorcl7declvalISS_EEEEE4typeEEE3endcl7declvalISS_EEEEE4typeEE7same_asISV_S11_EEENS_14adaptor_cursorISY_SV_EENS_16adaptor_sentinelIS14_S11_EEEEESO_IbLb1EEE4typeESS_
+	.align 2
+	.type	_ZNKR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv, @function
+_ZNKR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv:
+.LFB10167:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10167:
+	.size	_ZNKR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv, .-_ZNKR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv
+	.section	.text._ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv,"axG",@progbits,_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv,comdat
+	.align 2
+	.weak	_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	.type	_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv, @function
+_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv:
+.LFB10168:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10168:
+	.size	_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv, .-_ZNKR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	.section	.text._ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_,"axG",@progbits,_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_,comdat
+	.weak	_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_
+	.type	_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_, @function
+_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_:
+.LFB10169:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv
+	movq	(%rax), %rbx
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv
+	movq	(%rax), %rax
+	cmpq	%rax, %rbx
+	sete	%al
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10169:
+	.size	_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_, .-_ZN9__gnu_cxxeqIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEEbRKNS_17__normal_iteratorIT_T0_EESG_
+	.text
+	.align 2
+	.type	_ZNR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv, @function
+_ZNR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv:
+.LFB10170:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10170:
+	.size	_ZNR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv, .-_ZNR6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EE3getEv
+	.section	.text._ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv,"axG",@progbits,_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv,comdat
+	.align 2
+	.weak	_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	.type	_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv, @function
+_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv:
+.LFB10171:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10171:
+	.size	_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv, .-_ZNR6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EE3getEv
+	.section	.text._ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv,"axG",@progbits,_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv
+	.type	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv, @function
+_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv:
+.LFB10172:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	leaq	32(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, (%rax)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10172:
+	.size	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv, .-_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEppEv
+	.text
+	.align 2
+	.type	_ZNK6ranges9invoke_fnclIRKNS_17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESQ_DpSS_, @function
+_ZNK6ranges9invoke_fnclIRKNS_17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESQ_DpSS_:
+.LFB10173:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%rcx, -48(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-48(%rbp), %rdx
+	movq	-40(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEclIJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclL_ZNS_6invokeEEscRSB_dedtdefpT2t_spscOT_fp_EEDpSO_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L272
+	call	__stack_chk_fail@PLT
+.L272:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10173:
+	.size	_ZNK6ranges9invoke_fnclIRKNS_17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESQ_DpSS_, .-_ZNK6ranges9invoke_fnclIRKNS_17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRN9__gnu_cxx17__normal_iteratorIPSA_St6vectorISA_SaISA_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESQ_DpSS_
+	.section	.text._ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv,"axG",@progbits,_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv
+	.type	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv, @function
+_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv:
+.LFB10218:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10218:
+	.size	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv, .-_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8max_sizeEv
+	.section	.text._ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m,"axG",@progbits,_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m,comdat
+	.weak	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m
+	.type	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m, @function
+_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m:
+.LFB10219:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rcx
+	movq	-8(%rbp), %rax
+	movl	$0, %edx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10219:
+	.size	_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m, .-_ZNSt16allocator_traitsISaINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE8allocateERS6_m
+	.section	.text._ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m,"axG",@progbits,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m
+	.type	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m, @function
+_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m:
+.LFB10220:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-24(%rbp), %rax
+	salq	$5, %rax
+	movq	%rax, %rdx
+	movq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZdlPvm@PLT
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10220:
+	.size	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m, .-_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE10deallocateEPS6_m
+	.section	.text._ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_,"axG",@progbits,_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_,comdat
+	.weak	_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_
+	.type	_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_, @function
+_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_:
+.LFB10221:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA10221
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$56, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%rsi, -48(%rbp)
+	movq	%rdx, -56(%rbp)
+	movq	-40(%rbp), %rax
+	movq	%rax, -24(%rbp)
+	jmp	.L280
+.L281:
+	movq	-24(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_
+	movq	%rax, %rdx
+	movq	-56(%rbp), %rax
+	movq	%rax, %rsi
+	movq	%rdx, %rdi
+.LEHB24:
+	call	_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_
+.LEHE24:
+	subq	$1, -48(%rbp)
+	addq	$32, -24(%rbp)
+.L280:
+	cmpq	$0, -48(%rbp)
+	jne	.L281
+	movq	-24(%rbp), %rax
+	jmp	.L287
+.L285:
+	endbr64
+	movq	%rax, %rdi
+	call	__cxa_begin_catch@PLT
+	movq	-24(%rbp), %rdx
+	movq	-40(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+.LEHB25:
+	call	_ZSt8_DestroyIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvT_S7_
+	call	__cxa_rethrow@PLT
+.LEHE25:
+.L286:
+	endbr64
+	movq	%rax, %rbx
+	call	__cxa_end_catch@PLT
+	movq	%rbx, %rax
+	movq	%rax, %rdi
+.LEHB26:
+	call	_Unwind_Resume@PLT
+.LEHE26:
+.L287:
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10221:
+	.section	.gcc_except_table
+	.align 4
+.LLSDA10221:
+	.byte	0xff
+	.byte	0x9b
+	.uleb128 .LLSDATT10221-.LLSDATTD10221
+.LLSDATTD10221:
+	.byte	0x1
+	.uleb128 .LLSDACSE10221-.LLSDACSB10221
+.LLSDACSB10221:
+	.uleb128 .LEHB24-.LFB10221
+	.uleb128 .LEHE24-.LEHB24
+	.uleb128 .L285-.LFB10221
+	.uleb128 0x1
+	.uleb128 .LEHB25-.LFB10221
+	.uleb128 .LEHE25-.LEHB25
+	.uleb128 .L286-.LFB10221
+	.uleb128 0
+	.uleb128 .LEHB26-.LFB10221
+	.uleb128 .LEHE26-.LEHB26
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE10221:
+	.byte	0x1
+	.byte	0
+	.align 4
+	.long	0
+
+.LLSDATT10221:
+	.section	.text._ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_,"axG",@progbits,_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_,comdat
+	.size	_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_, .-_ZNSt22__uninitialized_fill_nILb0EE15__uninit_fill_nIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmS7_EET_S9_T0_RKT1_
+	.section	.text._ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_,"axG",@progbits,_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_,comdat
+	.weak	_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_
+	.type	_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_, @function
+_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_:
+.LFB10222:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10222:
+	.size	_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_, .-_ZSt11__addressofINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPT_RS6_
+	.section	.text._ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_,"axG",@progbits,_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_,comdat
+	.weak	_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_
+	.type	_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_, @function
+_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_:
+.LFB10223:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@PLT
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10223:
+	.size	_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_, .-_ZSt8_DestroyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEvPT_
+	.section	.text._ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_,"axG",@progbits,_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_,comdat
+	.weak	_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_
+	.type	_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_, @function
+_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_:
+.LFB10224:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10224:
+	.size	_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_, .-_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_
+	.text
+	.align 2
+	.type	_ZNK6ranges11indirect_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS_10indirectedIT_EESA_, @function
+_ZNK6ranges11indirect_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS_10indirectedIT_EESA_:
+.LFB10225:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -24(%rbp)
+	xorl	%eax, %eax
+	leaq	-41(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEONSt16remove_referenceIT_E4typeEOSB_
+	leaq	-25(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC1ES7_
+	movq	-24(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L295
+	call	__stack_chk_fail@PLT
+.L295:
+	movl	%ebx, %eax
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10225:
+	.size	_ZNK6ranges11indirect_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS_10indirectedIT_EESA_, .-_ZNK6ranges11indirect_fnclIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS_10indirectedIT_EESA_
+	.section	.rodata
+	.type	_ZN8concepts4defs7same_asIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS2_15semiregular_boxISB_EEEE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS2_15semiregular_boxISB_EEEE, 1
+_ZN8concepts4defs7same_asIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EENS2_15semiregular_boxISB_EEEE:
+	.zero	1
+	.text
+	.align 2
+	.type	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEEC2ESB_SE_, @function
+_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEEC2ESB_SE_:
+.LFB10227:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$40, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rbx
+	leaq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEEEONSt16remove_referenceIT_E4typeEOSE_
+	movq	%rax, %rsi
+	movq	%rbx, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EEC2EOSC_
+	movq	-24(%rbp), %rax
+	leaq	16(%rax), %rbx
+	leaq	-33(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEONSt16remove_referenceIT_E4typeEOSC_
+	movq	%rax, %rsi
+	movq	%rbx, %rdi
+	call	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC1IS9_Lb1ELi0ELi0ELi0EEEOT_
+	nop
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10227:
+	.size	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEEC2ESB_SE_, .-_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEEC2ESB_SE_
+	.type	_ZN6ranges12range_access13begin_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_13begin_adaptorEERT_, @function
+_ZN6ranges12range_access13begin_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_13begin_adaptorEERT_:
+.LFB10229:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE13begin_adaptorEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10229:
+	.size	_ZN6ranges12range_access13begin_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_13begin_adaptorEERT_, .-_ZN6ranges12range_access13begin_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_13begin_adaptorEERT_
+	.type	_ZN6ranges12adaptor_base5beginINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_5beginEEcldtfp_4baseEEERT_, @function
+_ZN6ranges12adaptor_base5beginINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_5beginEEcldtfp_4baseEEERT_:
+.LFB10230:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv
+	movq	%rax, %rsi
+	leaq	_ZN6ranges1_5beginE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10230:
+	.size	_ZN6ranges12adaptor_base5beginINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_5beginEEcldtfp_4baseEEERT_, .-_ZN6ranges12adaptor_base5beginINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_5beginEEcldtfp_4baseEEERT_
+	.section	.text._ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_,"axG",@progbits,_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_,comdat
+	.weak	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_
+	.type	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_, @function
+_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_:
+.LFB10231:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10231:
+	.size	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_, .-_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_
+	.text
+	.type	_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_, @function
+_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_:
+.LFB10232:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10232:
+	.size	_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_, .-_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_
+	.section	.rodata
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEJSK_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEJSK_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEJSK_EEE:
+	.byte	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_17reference_wrapperINS2_15semiregular_boxISH_EEEEEE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_17reference_wrapperINS2_15semiregular_boxISH_EEEEEE, 1
+_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_17reference_wrapperINS2_15semiregular_boxISH_EEEEEE:
+	.zero	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorISC_SaISC_EEEESE_E7adaptorILb0EEEEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorISC_SaISC_EEEESE_E7adaptorILb0EEEEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorISC_SaISC_EEEESE_E7adaptorILb0EEEEEE:
+	.zero	1
+	.type	_ZN8concepts4defs12destructibleIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEE, @object
+	.size	_ZN8concepts4defs12destructibleIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEE, 1
+_ZN8concepts4defs12destructibleIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEE:
+	.byte	1
+	.type	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_15semiregular_boxISH_EEEE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_15semiregular_boxISH_EEEE, 1
+_ZN8concepts4defs7same_asIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEENS2_15semiregular_boxISH_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorIS9_SaIS9_EEEESB_E7adaptorILb0EEEEEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorIS9_SaIS9_EEEESB_E7adaptorILb0EEEEEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEJNS2_19iter_transform_viewINS2_8ref_viewISt6vectorIS9_SaIS9_EEEESB_E7adaptorILb0EEEEEE:
+	.zero	1
+	.type	_ZN8concepts4defs7same_asIN6ranges3boxINS2_19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEEENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS2_6detail12box_compressE0EEESL_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges3boxINS2_19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEEENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS2_6detail12box_compressE0EEESL_EE, 1
+_ZN8concepts4defs7same_asIN6ranges3boxINS2_19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISC_EEEENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS2_6detail12box_compressE0EEESL_EE:
+	.zero	1
+	.type	_ZN8concepts4defs14convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, @object
+	.size	_ZN8concepts4defs14convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, 1
+_ZN8concepts4defs14convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25implicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, @object
+	.size	_ZN8concepts4defs25implicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, 1
+_ZN8concepts4defs25implicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE:
+	.byte	1
+	.type	_ZN8concepts4defs25explicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, @object
+	.size	_ZN8concepts4defs25explicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE, 1
+_ZN8concepts4defs25explicitly_convertible_toIN6ranges19iter_transform_viewINS2_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEEENS2_10indirectedIZ4mainEUlSB_E_EEE7adaptorILb0EEESK_EE:
+	.byte	1
+	.text
+	.align 2
+	.type	_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ISD_SM_Lb1ELi0ELi0EEEOT_OT0_, @function
+_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ISD_SM_Lb1ELi0ELi0EEEOT_OT0_:
+.LFB10236:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_
+	movq	-8(%rbp), %rax
+	leaq	8(%rax), %rdx
+	movq	-24(%rbp), %rax
+	movq	%rax, %rsi
+	movq	%rdx, %rdi
+	call	_ZN6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EEC2ISI_Lb1ELi0ELi0ELi0EEEOT_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10236:
+	.size	_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ISD_SM_Lb1ELi0ELi0EEEOT_OT0_, .-_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ISD_SM_Lb1ELi0ELi0EEEOT_OT0_
+	.set	_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC1ISD_SM_Lb1ELi0ELi0EEEOT_OT0_,_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ISD_SM_Lb1ELi0ELi0EEEOT_OT0_
+	.section	.text._ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_,"axG",@progbits,_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC5ISD_Lb1ELi0ELi0ELi0EEEOT_,comdat
+	.align 2
+	.weak	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_
+	.type	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_, @function
+_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_:
+.LFB10239:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	(%rdx), %rdx
+	movq	%rdx, (%rax)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10239:
+	.size	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_, .-_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_
+	.weak	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC1ISD_Lb1ELi0ELi0ELi0EEEOT_
+	.set	_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC1ISD_Lb1ELi0ELi0ELi0EEEOT_,_ZN6ranges3boxIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEESt17integral_constantImLm0EELNS_6detail12box_compressE0EEC2ISD_Lb1ELi0ELi0ELi0EEEOT_
+	.text
+	.align 2
+	.type	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ESD_SM_, @function
+_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ESD_SM_:
+.LFB10241:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%r12
+	pushq	%rbx
+	subq	$32, %rsp
+	.cfi_offset 12, -24
+	.cfi_offset 3, -32
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	-24(%rbp), %rbx
+	leaq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS7_SaIS7_EEEEEONSt16remove_referenceIT_E4typeEOSF_
+	movq	%rax, %r12
+	leaq	-40(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges19iter_transform_viewINS0_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS0_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEONSt16remove_referenceIT_E4typeEOSL_
+	movq	%rax, %rdx
+	movq	%r12, %rsi
+	movq	%rbx, %rdi
+	call	_ZN6ranges15compressed_pairIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC1ISD_SM_Lb1ELi0ELi0EEEOT_OT0_
+	nop
+	addq	$32, %rsp
+	popq	%rbx
+	popq	%r12
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10241:
+	.size	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ESD_SM_, .-_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ESD_SM_
+	.set	_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC1ESD_SM_,_ZN6ranges14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS8_SaIS8_EEEENS_19iter_transform_viewINS_8ref_viewISC_EENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEEEC2ESD_SM_
+	.section	.rodata
+	.type	_ZN8concepts4defs7same_asIN6ranges3boxINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEvLNS2_6detail12box_compressE0EEESR_EE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges3boxINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEvLNS2_6detail12box_compressE0EEESR_EE, 1
+_ZN8concepts4defs7same_asIN6ranges3boxINS2_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISC_SaISC_EEEENS2_19iter_transform_viewINS2_8ref_viewISG_EENS2_10indirectedIZ4mainEUlSC_E_EEE7adaptorILb0EEEEEvLNS2_6detail12box_compressE0EEESR_EE:
+	.zero	1
+	.text
+	.align 2
+	.type	_ZN6ranges11basic_mixinINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2IL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEEOSO_NSt9enable_ifIXaaL_ZNSR_4defs18move_constructibleISO_EEEclT_tlST_EEEST_E4typeE, @function
+_ZN6ranges11basic_mixinINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2IL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEEOSO_NSt9enable_ifIXaaL_ZNSR_4defs18move_constructibleISO_EEEclT_tlST_EEEST_E4typeE:
+.LFB10244:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rbx
+	movq	-32(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail4moveIRNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEONSt16remove_referenceIT_E4typeEOSS_
+	movq	%rax, %rsi
+	movq	%rbx, %rdi
+	call	_ZN6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EEC2ISO_Lb1ELi0ELi0ELi0EEEOT_
+	nop
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10244:
+	.size	_ZN6ranges11basic_mixinINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2IL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEEOSO_NSt9enable_ifIXaaL_ZNSR_4defs18move_constructibleISO_EEEclT_tlST_EEEST_E4typeE, .-_ZN6ranges11basic_mixinINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEEC2IL_ZN8concepts6detail11CPP_true_fnENSS_3NilEEEEOSO_NSt9enable_ifIXaaL_ZNSR_4defs18move_constructibleISO_EEEclT_tlST_EEEST_E4typeE
+	.type	_ZN6ranges12range_access11end_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_11end_adaptorEERT_, @function
+_ZN6ranges12range_access11end_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_11end_adaptorEERT_:
+.LFB10246:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE11end_adaptorEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10246:
+	.size	_ZN6ranges12range_access11end_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_11end_adaptorEERT_, .-_ZN6ranges12range_access11end_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTcldtfp_11end_adaptorEERT_
+	.type	_ZN6ranges12adaptor_base3endINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_3endEEcldtfp_4baseEEERT_, @function
+_ZN6ranges12adaptor_base3endINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_3endEEcldtfp_4baseEEERT_:
+.LFB10247:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv
+	movq	%rax, %rsi
+	leaq	_ZN6ranges1_3endE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10247:
+	.size	_ZN6ranges12adaptor_base3endINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_3endEEcldtfp_4baseEEERT_, .-_ZN6ranges12adaptor_base3endINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEENS_10indirectedIZ4mainEUlSA_E_EEEEEEDTclL_ZNS_1_3endEEcldtfp_4baseEEERT_
+	.section	.text._ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv,"axG",@progbits,_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv
+	.type	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv, @function
+_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv:
+.LFB10248:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10248:
+	.size	_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv, .-_ZNK9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEE4baseEv
+	.text
+	.align 2
+	.type	_ZNK6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEclIJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclL_ZNS_6invokeEEscRSB_dedtdefpT2t_spscOT_fp_EEDpSO_, @function
+_ZNK6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEclIJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclL_ZNS_6invokeEEscRSB_dedtdefpT2t_spscOT_fp_EEDpSO_:
+.LFB10249:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-32(%rbp), %rax
+	movq	(%rax), %rdx
+	movq	-24(%rbp), %rax
+	movq	-40(%rbp), %rcx
+	leaq	_ZN6ranges6invokeE(%rip), %rsi
+	movq	%rax, %rdi
+	call	_ZNK6ranges9invoke_fnclIRNS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESN_DpSP_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L317
+	call	__stack_chk_fail@PLT
+.L317:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10249:
+	.size	_ZNK6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEclIJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclL_ZNS_6invokeEEscRSB_dedtdefpT2t_spscOT_fp_EEDpSO_, .-_ZNK6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEclIJRN9__gnu_cxx17__normal_iteratorIPS8_St6vectorIS8_SaIS8_EEEEEEEDTclL_ZNS_6invokeEEscRSB_dedtdefpT2t_spscOT_fp_EEDpSO_
+	.section	.text._ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv,"axG",@progbits,_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv,comdat
+	.align 2
+	.weak	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv
+	.type	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv, @function
+_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv:
+.LFB10275:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movabsq	$288230376151711743, %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10275:
+	.size	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv, .-_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv
+	.section	.text._ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv,"axG",@progbits,_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv
+	.type	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv, @function
+_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv:
+.LFB10276:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	%rdx, -24(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE11_M_max_sizeEv
+	cmpq	%rax, -16(%rbp)
+	seta	%al
+	movzbl	%al, %eax
+	testq	%rax, %rax
+	setne	%al
+	testb	%al, %al
+	je	.L321
+	movabsq	$576460752303423487, %rax
+	cmpq	%rax, -16(%rbp)
+	jbe	.L322
+	call	_ZSt28__throw_bad_array_new_lengthv@PLT
+.L322:
+	call	_ZSt17__throw_bad_allocv@PLT
+.L321:
+	movq	-16(%rbp), %rax
+	salq	$5, %rax
+	movq	%rax, %rdi
+	call	_Znwm@PLT
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10276:
+	.size	_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv, .-_ZN9__gnu_cxx13new_allocatorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE8allocateEmPKv
+	.section	.text._ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_,"axG",@progbits,_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_,comdat
+	.weak	_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_
+	.type	_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_, @function
+_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_:
+.LFB10277:
+	.cfi_startproc
+	.cfi_personality 0x9b,DW.ref.__gxx_personality_v0
+	.cfi_lsda 0x1b,.LLSDA10277
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%r13
+	pushq	%r12
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 13, -24
+	.cfi_offset 12, -32
+	.cfi_offset 3, -40
+	movq	%rdi, -40(%rbp)
+	movq	%rsi, -48(%rbp)
+	movq	-48(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE
+	movq	%rax, %r13
+	movq	-40(%rbp), %rbx
+	movq	%rbx, %rsi
+	movl	$32, %edi
+	call	_ZnwmPv
+	movq	%rax, %r12
+	movq	%r13, %rsi
+	movq	%r12, %rdi
+.LEHB27:
+	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1ERKS4_@PLT
+.LEHE27:
+	jmp	.L327
+.L326:
+	endbr64
+	movq	%rax, %r13
+	movq	%rbx, %rsi
+	movq	%r12, %rdi
+	call	_ZdlPvS_
+	movq	%r13, %rax
+	movq	%rax, %rdi
+.LEHB28:
+	call	_Unwind_Resume@PLT
+.LEHE28:
+.L327:
+	addq	$24, %rsp
+	popq	%rbx
+	popq	%r12
+	popq	%r13
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10277:
+	.section	.gcc_except_table
+.LLSDA10277:
+	.byte	0xff
+	.byte	0xff
+	.byte	0x1
+	.uleb128 .LLSDACSE10277-.LLSDACSB10277
+.LLSDACSB10277:
+	.uleb128 .LEHB27-.LFB10277
+	.uleb128 .LEHE27-.LEHB27
+	.uleb128 .L326-.LFB10277
+	.uleb128 0
+	.uleb128 .LEHB28-.LFB10277
+	.uleb128 .LEHE28-.LEHB28
+	.uleb128 0
+	.uleb128 0
+.LLSDACSE10277:
+	.section	.text._ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_,"axG",@progbits,_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_,comdat
+	.size	_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_, .-_ZSt10_ConstructINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJRKS5_EEvPT_DpOT0_
+	.text
+	.type	_ZN6ranges6detail4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEONSt16remove_referenceIT_E4typeEOSB_, @function
+_ZN6ranges6detail4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEONSt16remove_referenceIT_E4typeEOSB_:
+.LFB10278:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10278:
+	.size	_ZN6ranges6detail4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEONSt16remove_referenceIT_E4typeEOSB_, .-_ZN6ranges6detail4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEONSt16remove_referenceIT_E4typeEOSB_
+	.align 2
+	.type	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC2ES7_, @function
+_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC2ES7_:
+.LFB10280:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	leaq	-9(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EONSt16remove_referenceIT_E4typeEOS9_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10280:
+	.size	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC2ES7_, .-_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC2ES7_
+	.set	_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC1ES7_,_ZN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EC2ES7_
+	.type	_ZSt4moveIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEONSt16remove_referenceIT_E4typeEOSC_, @function
+_ZSt4moveIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEONSt16remove_referenceIT_E4typeEOSC_:
+.LFB10282:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10282:
+	.size	_ZSt4moveIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEONSt16remove_referenceIT_E4typeEOSC_, .-_ZSt4moveIRN6ranges10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEONSt16remove_referenceIT_E4typeEOSC_
+	.align 2
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EEC2EOSC_, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EEC2EOSC_:
+.LFB10284:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	pushq	%rbx
+	subq	$24, %rsp
+	.cfi_offset 3, -24
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	-24(%rbp), %rbx
+	movq	-32(%rbp), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges5views3allE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges5views6all_fnclINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEDaOT_
+	movq	%rax, 8(%rbx)
+	nop
+	movq	-8(%rbp), %rbx
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10284:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EEC2EOSC_, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EEC2EOSC_
+	.align 2
+	.type	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_, @function
+_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_:
+.LFB10288:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movb	$1, 1(%rax)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10288:
+	.size	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_, .-_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_
+	.set	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC1IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_,_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_
+	.align 2
+	.type	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IS9_Lb1ELi0ELi0ELi0EEEOT_, @function
+_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IS9_Lb1ELi0ELi0ELi0EEEOT_:
+.LFB10290:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC1IJS9_ELb1ELi0EEENS_10in_place_tEDpOT_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10290:
+	.size	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IS9_Lb1ELi0ELi0ELi0EEEOT_, .-_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IS9_Lb1ELi0ELi0ELi0EEEOT_
+	.set	_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC1IS9_Lb1ELi0ELi0ELi0EEEOT_,_ZN6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEC2IS9_Lb1ELi0ELi0ELi0EEEOT_
+	.section	.rodata
+	.type	_ZN8concepts4defs7same_asIN6ranges15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEENS2_17reference_wrapperISD_EEEE, @object
+	.size	_ZN8concepts4defs7same_asIN6ranges15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEENS2_17reference_wrapperISD_EEEE, 1
+_ZN8concepts4defs7same_asIN6ranges15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEENS2_17reference_wrapperISD_EEEE:
+	.zero	1
+	.type	_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRSF_EEE, @object
+	.size	_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRSF_EEE, 1
+_ZN8concepts4defs18constructible_fromIN6ranges6detail18reference_wrapper_INS2_15semiregular_boxINS2_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEJRSF_EEE:
+	.byte	1
+	.text
+	.align 2
+	.type	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE13begin_adaptorEv, @function
+_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE13begin_adaptorEv:
+.LFB10292:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-40(%rbp), %rax
+	leaq	16(%rax), %rdx
+	leaq	-24(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC1IRSB_Lb1ELi0ELi0EEEOT_
+	movq	-24(%rbp), %rdx
+	leaq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC1ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE
+	movq	-16(%rbp), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L338
+	call	__stack_chk_fail@PLT
+.L338:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10292:
+	.size	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE13begin_adaptorEv, .-_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE13begin_adaptorEv
+	.align 2
+	.type	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv, @function
+_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv:
+.LFB10293:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	addq	$8, %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10293:
+	.size	_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv, .-_ZN6ranges12view_adaptorINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEEESC_LNS_11cardinalityEn1EE4baseEv
+	.section	.text._ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_,"axG",@progbits,_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_,comdat
+	.align 2
+	.weak	_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	.type	_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_, @function
+_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_:
+.LFB10294:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10294:
+	.size	_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_, .-_ZNK6ranges7_begin_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	.text
+	.align 2
+	.type	_ZN6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EEC2ISI_Lb1ELi0ELi0ELi0EEEOT_, @function
+_ZN6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EEC2ISI_Lb1ELi0ELi0ELi0EEEOT_:
+.LFB10296:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	(%rdx), %rdx
+	movq	%rdx, (%rax)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10296:
+	.size	_ZN6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EEC2ISI_Lb1ELi0ELi0ELi0EEEOT_, .-_ZN6ranges3boxINS_19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEEENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEESt17integral_constantImLm1EELNS_6detail12box_compressE0EEC2ISI_Lb1ELi0ELi0ELi0EEEOT_
+	.type	_ZN6ranges6detail4moveIRNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEONSt16remove_referenceIT_E4typeEOSS_, @function
+_ZN6ranges6detail4moveIRNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEONSt16remove_referenceIT_E4typeEOSS_:
+.LFB10298:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10298:
+	.size	_ZN6ranges6detail4moveIRNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEONSt16remove_referenceIT_E4typeEOSS_, .-_ZN6ranges6detail4moveIRNS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorISA_SaISA_EEEENS_19iter_transform_viewINS_8ref_viewISE_EENS_10indirectedIZ4mainEUlSA_E_EEE7adaptorILb0EEEEEEEONSt16remove_referenceIT_E4typeEOSS_
+	.align 2
+	.type	_ZN6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EEC2ISO_Lb1ELi0ELi0ELi0EEEOT_, @function
+_ZN6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EEC2ISO_Lb1ELi0ELi0ELi0EEEOT_:
+.LFB10300:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rcx
+	movq	-16(%rbp), %rax
+	movq	8(%rax), %rdx
+	movq	(%rax), %rax
+	movq	%rax, (%rcx)
+	movq	%rdx, 8(%rcx)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10300:
+	.size	_ZN6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EEC2ISO_Lb1ELi0ELi0ELi0EEEOT_, .-_ZN6ranges3boxINS_14adaptor_cursorIN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS9_SaIS9_EEEENS_19iter_transform_viewINS_8ref_viewISD_EENS_10indirectedIZ4mainEUlS9_E_EEE7adaptorILb0EEEEEvLNS_6detail12box_compressE0EEC2ISO_Lb1ELi0ELi0ELi0EEEOT_
+	.align 2
+	.type	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE11end_adaptorEv, @function
+_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE11end_adaptorEv:
+.LFB10302:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -40(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-40(%rbp), %rax
+	leaq	16(%rax), %rdx
+	leaq	-24(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC1IRSB_Lb1ELi0ELi0EEEOT_
+	movq	-24(%rbp), %rdx
+	leaq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC1ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE
+	movq	-16(%rbp), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L349
+	call	__stack_chk_fail@PLT
+.L349:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10302:
+	.size	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE11end_adaptorEv, .-_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE11end_adaptorEv
+	.section	.text._ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_,"axG",@progbits,_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_,comdat
+	.align 2
+	.weak	_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	.type	_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_, @function
+_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_:
+.LFB10303:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10303:
+	.size	_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_, .-_ZNK6ranges5_end_2fnclIRNS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISA_EEEELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISI_EEOSI_
+	.text
+	.align 2
+	.type	_ZNK6ranges9invoke_fnclIRNS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESN_DpSP_, @function
+_ZNK6ranges9invoke_fnclIRNS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESN_DpSP_:
+.LFB10304:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$48, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%rsi, -32(%rbp)
+	movq	%rdx, -40(%rbp)
+	movq	%rcx, -48(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	movq	-48(%rbp), %rdx
+	movq	-40(%rbp), %rcx
+	movq	%rcx, %rsi
+	movq	%rax, %rdi
+	call	_ZNR6ranges15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEclIJRN9__gnu_cxx17__normal_iteratorIPS7_St6vectorIS7_SaIS7_EEEEELb1ELi0EEEDcDpOT_
+	movq	-8(%rbp), %rax
+	subq	%fs:40, %rax
+	je	.L354
+	call	__stack_chk_fail@PLT
+.L354:
+	movq	-24(%rbp), %rax
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10304:
+	.size	_ZNK6ranges9invoke_fnclIRNS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESN_DpSP_, .-_ZNK6ranges9invoke_fnclIRNS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEJRN9__gnu_cxx17__normal_iteratorIPS9_St6vectorIS9_SaIS9_EEEEEEEDTclcvOT_fp_spcvOT0_fp0_EESN_DpSP_
+	.section	.text._ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE,"axG",@progbits,_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE,comdat
+	.weak	_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE
+	.type	_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE, @function
+_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE:
+.LFB10317:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10317:
+	.size	_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE, .-_ZSt7forwardIRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEOT_RNSt16remove_referenceIS8_E4typeE
+	.text
+	.align 2
+	.type	_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2IRSB_Lb1ELi0ELi0EEEOT_, @function
+_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2IRSB_Lb1ELi0ELi0EEEOT_:
+.LFB10319:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-8(%rbp), %rax
+	movq	-16(%rbp), %rdx
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN6ranges6detail18reference_wrapper_INS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2ERSC_
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10319:
+	.size	_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2IRSB_Lb1ELi0ELi0EEEOT_, .-_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2IRSB_Lb1ELi0ELi0EEEOT_
+	.set	_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC1IRSB_Lb1ELi0ELi0EEEOT_,_ZN6ranges17reference_wrapperINS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2IRSB_Lb1ELi0ELi0EEEOT_
+	.align 2
+	.type	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC2ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE, @function
+_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC2ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE:
+.LFB10322:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	leaq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt4moveIRN6ranges17reference_wrapperINS0_15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEONSt16remove_referenceIT_E4typeEOSG_
+	movq	-8(%rbp), %rdx
+	movq	(%rax), %rax
+	movq	%rax, (%rdx)
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10322:
+	.size	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC2ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE, .-_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC2ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE
+	.set	_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC1ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE,_ZN6ranges19iter_transform_viewINS_8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS8_EEEENS_10indirectedIZ4mainEUlS8_E_EEE7adaptorILb0EEC2ENS_17reference_wrapperINS_15semiregular_boxISE_EEEE
+	.section	.text._ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv,"axG",@progbits,_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv,comdat
+	.align 2
+	.weak	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv
+	.type	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv, @function
+_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv:
+.LFB10324:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges1_5beginE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10324:
+	.size	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv, .-_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE5beginEv
+	.section	.text._ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv,"axG",@progbits,_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv,comdat
+	.align 2
+	.weak	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv
+	.type	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv, @function
+_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv:
+.LFB10325:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	(%rax), %rax
+	movq	%rax, %rsi
+	leaq	_ZN6ranges1_3endE(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10325:
+	.size	_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv, .-_ZNK6ranges8ref_viewISt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EEE3endEv
+	.text
+	.align 2
+	.type	_ZN6ranges6detail18reference_wrapper_INS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2ERSC_, @function
+_ZN6ranges6detail18reference_wrapper_INS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2ERSC_:
+.LFB10329:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt9addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_
+	movq	-8(%rbp), %rdx
+	movq	%rax, (%rdx)
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10329:
+	.size	_ZN6ranges6detail18reference_wrapper_INS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2ERSC_, .-_ZN6ranges6detail18reference_wrapper_INS_15semiregular_boxINS_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEC2ERSC_
+	.type	_ZSt4moveIRN6ranges17reference_wrapperINS0_15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEONSt16remove_referenceIT_E4typeEOSG_, @function
+_ZSt4moveIRN6ranges17reference_wrapperINS0_15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEONSt16remove_referenceIT_E4typeEOSG_:
+.LFB10331:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10331:
+	.size	_ZSt4moveIRN6ranges17reference_wrapperINS0_15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEONSt16remove_referenceIT_E4typeEOSG_, .-_ZSt4moveIRN6ranges17reference_wrapperINS0_15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEEEONSt16remove_referenceIT_E4typeEOSG_
+	.section	.text._ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_,"axG",@progbits,_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_,comdat
+	.align 2
+	.weak	_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	.type	_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_, @function
+_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_:
+.LFB10332:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10332:
+	.size	_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_, .-_ZNK6ranges7_begin_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX16has_member_beginIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	.section	.text._ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_,"axG",@progbits,_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_,comdat
+	.align 2
+	.weak	_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	.type	_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_, @function
+_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_:
+.LFB10333:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10333:
+	.size	_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_, .-_ZNK6ranges5_end_2fnclIRSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EELb1ELi0ELi0EEEN4meta6detail5_condIX14has_member_endIT_EEE6invokeINS1_15_member_result_ENS1_19_non_member_result_EE6invokeISG_EEOSG_
+	.text
+	.type	_ZSt9addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_, @function
+_ZSt9addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_:
+.LFB10334:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	movq	%rax, %rdi
+	call	_ZSt11__addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10334:
+	.size	_ZSt9addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_, .-_ZSt9addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv,comdat
+	.align 2
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv:
+.LFB10335:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rdx
+	leaq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC1ERKS7_
+	movq	-16(%rbp), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L374
+	call	__stack_chk_fail@PLT
+.L374:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10335:
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE5beginEv
+	.section	.text._ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv,"axG",@progbits,_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv,comdat
+	.align 2
+	.weak	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv
+	.type	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv, @function
+_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv:
+.LFB10336:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$32, %rsp
+	movq	%rdi, -24(%rbp)
+	movq	%fs:40, %rax
+	movq	%rax, -8(%rbp)
+	xorl	%eax, %eax
+	movq	-24(%rbp), %rax
+	leaq	8(%rax), %rdx
+	leaq	-16(%rbp), %rax
+	movq	%rdx, %rsi
+	movq	%rax, %rdi
+	call	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC1ERKS7_
+	movq	-16(%rbp), %rax
+	movq	-8(%rbp), %rdx
+	subq	%fs:40, %rdx
+	je	.L377
+	call	__stack_chk_fail@PLT
+.L377:
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10336:
+	.size	_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv, .-_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE3endEv
+	.text
+	.type	_ZSt11__addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_, @function
+_ZSt11__addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_:
+.LFB10337:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	-8(%rbp), %rax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10337:
+	.size	_ZSt11__addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_, .-_ZSt11__addressofIN6ranges15semiregular_boxINS0_10indirectedIZ4mainEUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE_EEEEEPT_RSC_
+	.section	.text._ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_,"axG",@progbits,_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC5ERKS7_,comdat
+	.align 2
+	.weak	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_
+	.type	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_, @function
+_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_:
+.LFB10339:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	%rdi, -8(%rbp)
+	movq	%rsi, -16(%rbp)
+	movq	-16(%rbp), %rax
+	movq	(%rax), %rdx
+	movq	-8(%rbp), %rax
+	movq	%rdx, (%rax)
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10339:
+	.size	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_, .-_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_
+	.weak	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC1ERKS7_
+	.set	_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC1ERKS7_,_ZN9__gnu_cxx17__normal_iteratorIPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt6vectorIS6_SaIS6_EEEC2ERKS7_
+	.text
+	.type	_Z41__static_initialization_and_destruction_0ii, @function
+_Z41__static_initialization_and_destruction_0ii:
+.LFB10361:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	subq	$16, %rsp
+	movl	%edi, -4(%rbp)
+	movl	%esi, -8(%rbp)
+	cmpl	$1, -4(%rbp)
+	jne	.L383
+	cmpl	$65535, -8(%rbp)
+	jne	.L383
+	leaq	_ZStL8__ioinit(%rip), %rax
+	movq	%rax, %rdi
+	call	_ZNSt8ios_base4InitC1Ev@PLT
+	leaq	__dso_handle(%rip), %rax
+	movq	%rax, %rdx
+	leaq	_ZStL8__ioinit(%rip), %rax
+	movq	%rax, %rsi
+	movq	_ZNSt8ios_base4InitD1Ev@GOTPCREL(%rip), %rax
+	movq	%rax, %rdi
+	call	__cxa_atexit@PLT
+.L383:
+	nop
+	leave
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10361:
+	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
+	.type	_GLOBAL__sub_I_main, @function
+_GLOBAL__sub_I_main:
+.LFB10362:
+	.cfi_startproc
+	endbr64
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movl	$65535, %esi
+	movl	$1, %edi
+	call	_Z41__static_initialization_and_destruction_0ii
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE10362:
+	.size	_GLOBAL__sub_I_main, .-_GLOBAL__sub_I_main
+	.section	.init_array,"aw"
+	.align 8
+	.quad	_GLOBAL__sub_I_main
+	.section	.rodata
+	.align 8
+.LC1:
+	.long	0
+	.long	1074266112
+	.align 8
+.LC2:
+	.long	0
+	.long	1138753536
+	.hidden	DW.ref.__gxx_personality_v0
+	.weak	DW.ref.__gxx_personality_v0
+	.section	.data.rel.local.DW.ref.__gxx_personality_v0,"awG",@progbits,DW.ref.__gxx_personality_v0,comdat
+	.align 8
+	.type	DW.ref.__gxx_personality_v0, @object
+	.size	DW.ref.__gxx_personality_v0, 8
+DW.ref.__gxx_personality_v0:
+	.quad	__gxx_personality_v0
+	.hidden	__dso_handle
+	.ident	"GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
+	.section	.note.GNU-stack,"",@progbits
+	.section	.note.gnu.property,"a"
+	.align 8
+	.long	1f - 0f
+	.long	4f - 1f
+	.long	5
+0:
+	.string	"GNU"
+1:
+	.align 8
+	.long	0xc0000002
+	.long	3f - 2f
+2:
+	.long	0x3
+3:
+	.align 8
+4:

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -205,13 +205,8 @@ fn main_loop(
                     // format response
                     match word {
                         Ok(word) => {
-                            let hover_res = get_hover_resp(&word, names_to_instructions);
-                            // If no instructions matched, check the registers
-                            let hover_res = if hover_res.is_none() {
-                                get_hover_resp(&word, names_to_registers)
-                            } else {
-                                hover_res
-                            };
+                            let hover_res =
+                                get_hover_resp(&word, names_to_instructions, names_to_registers);
                             match hover_res {
                                 Some(_) => {
                                     let result = serde_json::to_value(&hover_res).unwrap();


### PR DESCRIPTION
This PR adds name demangling support on hover using the [symbolic crate](https://crates.io/crates/symbolic). This crate supports demangling for C++ (GCC, clang and MSVC), Objective C / Objective C++, Rust, and Swift. As one of the main goals of this LSP is to help users explore the assembly output of a compiled program, I think this feature should be helpful. Here's an example gif: 

![demangle](https://github.com/bergercookie/asm-lsp/assets/87077023/85485923-b09c-4bd3-ab6d-6ce9c82b6347)
