### PR TITLE
feat: Header doc link

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -214,15 +214,12 @@ fn main_loop(
                     };
 
                     // get the word under the cursor
-                    let word = get_word_from_file_params(&params.text_document_position_params);
+                    let word = get_word_from_file_params(&params.text_document_position_params, "");
                     // treat the word under the cursor as a filename and grab it as well
                     let file_word = if let Some(ref doc) = curr_doc {
-                        Some(get_filename_from_pos_params(
-                            doc,
-                            &params.text_document_position_params,
-                        ))
+                        get_word_from_pos_params(doc, &params.text_document_position_params, ".")
                     } else {
-                        None
+                        ""
                     };
 
                     // get documentation ------------------------------------------------------

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use asm_lsp::*;
 
 use log::{error, info};
@@ -163,6 +165,8 @@ pub fn main() -> anyhow::Result<()> {
     let reg_completion_items =
         get_completes(&names_to_registers, Some(CompletionItemKind::VARIABLE));
 
+    let include_dirs = get_include_dirs();
+
     main_loop(
         &connection,
         initialization_params,
@@ -170,6 +174,7 @@ pub fn main() -> anyhow::Result<()> {
         &names_to_registers,
         &instr_completion_items,
         &reg_completion_items,
+        &include_dirs,
     )?;
     io_threads.join()?;
 
@@ -185,6 +190,7 @@ fn main_loop(
     names_to_registers: &NameToRegisterMap,
     instruction_completion_items: &[CompletionItem],
     register_completion_items: &[CompletionItem],
+    include_dirs: &[PathBuf],
 ) -> anyhow::Result<()> {
     let _params: InitializeParams = serde_json::from_value(params).unwrap();
     let mut curr_doc: Option<FullTextDocument> = None;
@@ -209,13 +215,27 @@ fn main_loop(
 
                     // get the word under the cursor
                     let word = get_word_from_file_params(&params.text_document_position_params);
+                    // treat the word under the cursor as a filename and grab it as well
+                    let file_word = if let Some(ref doc) = curr_doc {
+                        Some(get_filename_from_pos_params(
+                            doc,
+                            &params.text_document_position_params,
+                        ))
+                    } else {
+                        None
+                    };
 
                     // get documentation ------------------------------------------------------
                     // format response
                     match word {
                         Ok(word) => {
-                            let hover_res =
-                                get_hover_resp(&word, names_to_instructions, names_to_registers);
+                            let hover_res = get_hover_resp(
+                                &word,
+                                file_word,
+                                names_to_instructions,
+                                names_to_registers,
+                                include_dirs,
+                            );
                             match hover_res {
                                 Some(_) => {
                                     let result = serde_json::to_value(&hover_res).unwrap();


### PR DESCRIPTION
This PR adds basic document link on hover as requested in #45.

At start up time, the server issues ``gcc`` and ``clang`` commands to see the default header search paths on the current system. The output from those commands is parsed, and when a hover request is made those directories are searched for a file with a name matching the requested hover word. If there are better ways to grab this information (e.g. better commands, or some gcc/clang bindings to get the information programmatically), I'd be thrilled to swap out what I currently have. This functions well enough for basic system headers, but by no means provides complete coverage.  Here's a gif example:

![doclink](https://github.com/bergercookie/asm-lsp/assets/87077023/1aff2d6b-80e6-4e8f-b69a-d392d9cd5426)

If this is ok to merge with the current approach, I think it may be a good idea to add an optional "additional_includes" field to the config struct/file that could be searched in addition to the gcc/clang locations. Let me know what you think :)


Closes #45 