### PR TITLE
feat: Add JSON schema

### DIFF
--- a/asm-lsp_config_schema.json
+++ b/asm-lsp_config_schema.json
@@ -1,0 +1,44 @@
+{
+    "$id": "asm-lsp_config_schema.json",
+    "$schema": "http://json-schema.org/schema",
+    "title": "asm-lsp Configuration Schema",
+    "description": "Configuration for asm-lsp.",
+    "type": "object",
+    "properties": {
+        "version": {
+            "description": "Config version number.",
+            "type": "string"
+        },
+        "assemblers": {
+            "description": "Options to manage assembler-dependent features.",
+            "type": "object",
+            "properties": {
+                "gas": {
+                    "description": "Flag to turn features related to the GNU Assembler on/off.",
+                    "type": "boolean"
+                },
+                "go": {
+                    "description": "Flag to turn features related to the Go Assembler on/off.",
+                    "type": "boolean"
+                }
+            },
+            "required": [ "gas", "go" ]
+        },
+        "instruction_sets": {
+            "description": "Options to manage instruction set-dependent features.",
+            "type": "object",
+            "properties": {
+                "x86": {
+                    "description": "Flag to turn features related to the x86 instruction set on/off.",
+                    "type": "boolean"
+                },
+                "x86_64": {
+                    "description": "Flag to turn features related to the x86_64 instruction set on/off.",
+                    "type": "boolean"
+                }
+            },
+            "required": [ "x86", "x86_64" ]
+        }
+    },
+    "required": [ "version", "assemblers", "instruction_sets" ]
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -358,7 +358,7 @@ fn main_loop(
                         connection.sender.send(Message::Response(res.clone()))?;
                     }
                 } else {
-                    error!("Invalid request fromat -> {:#?}", req);
+                    error!("Invalid request format -> {:#?}", req);
                 }
             }
             Message::Notification(notif) => {


### PR DESCRIPTION
This PR adds a JSON schema for the project's `.asm-lsp.toml` config file. I validated the schema using the [pajv](https://github.com/json-schema-everywhere/pajv) CLI tool. I tried but was unable to find any other tools that validated `.toml` data files against json schemas. If anyone else is aware of such a tool, feel free to comment here. 

I'm not super familiar with these tools/ how they're used yet. Since you opened the issue @Freed-Wu,  if you could test the schema (I'm not familiar with which tools actually use this information) I have here to make sure everything is set before merging that would be greatly appreciated. 😄 

If this schema looks ok, I'll go ahead and open a PR on [schemastore's repo](https://github.com/SchemaStore/schemastore) to add it for others to use. 

Closes #60 