### PR TITLE
Fix case sensitivity bug

### DIFF
--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -50,6 +50,7 @@ pub fn populate_instructions(xml_contents: &str) -> anyhow::Result<Vec<Instructi
                                 "name" => unsafe {
                                     let name = String::from(str::from_utf8_unchecked(&value));
                                     curr_instruction.alt_names.push(name.to_uppercase());
+                                    curr_instruction.alt_names.push(name.to_lowercase());
                                     curr_instruction.name = name;
                                 },
                                 "summary" => unsafe {
@@ -340,6 +341,7 @@ pub fn populate_registers(xml_contents: &str) -> anyhow::Result<Vec<Register>> {
                                 "name" => unsafe {
                                     let name_ = String::from(str::from_utf8_unchecked(&value));
                                     curr_register.alt_names.push(name_.to_uppercase());
+                                    curr_register.alt_names.push(name_.to_lowercase());
                                     curr_register.name = name_;
                                 },
                                 "altname" => unsafe {


### PR DESCRIPTION
While testing something else I realized some of the instruction names inside of xml files are actually in upper case, for example XOR's entry:
```xml
  <Instruction name="XOR" summary="Logical Exclusive OR">
    <InstructionForm gas-name="xorb" go-name="XORB">
      <Operand type="al" input="true" output="true"/>
      <Operand type="imm8"/>
      <Encoding>
        <Opcode byte="34"/>
        <Immediate size="1" value="#1"/>
      </Encoding>
    </InstructionForm>
    <InstructionForm gas-name="xorb" go-name="XORB">
    ...
  </Instruction>
```

This means that currently the LSP will respond to a hover request for `XOR`, but not for `xor`. This PR provides a patch by adding both the `.to_uppercase()` and `.to_lowercase()` variants of the instruction name at load time. A cleaner solution would be to just do case insensitive insensitive lookup into the hashmap, if we can get around https://github.com/rust-lang/rust/issues/80389. 

I'll go ahead and merge this for now to get the fix in, but I'd like to replace the use of the `alt_names` field in the `Register` and `Instruction` structs with a cleaner solution at some point.