### PR TITLE
refactor: Assign Register and Instruction `arch` field at read time

### DIFF
--- a/registers/x86_64.xml
+++ b/registers/x86_64.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<InstructionSet name="x86_64">
+<InstructionSet name="x86-64">
     <Register name="rax" description="Accumulator" type="General Purpose Register" width="64 bits">
     </Register>
     <Register name="eax" description="Accumulator" type="General Purpose Register" width="32 bits">

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -84,10 +84,6 @@ pub fn main() -> anyhow::Result<()> {
         let xml_conts_x86 = include_str!("../../opcodes/x86.xml");
         populate_instructions(xml_conts_x86)?
             .into_iter()
-            .map(|mut instruction| {
-                instruction.arch = Some(Arch::X86);
-                instruction
-            })
             .map(|instruction| {
                 // filter out assemblers by user config
                 instr_filter_targets(&instruction, &target_config)
@@ -103,10 +99,6 @@ pub fn main() -> anyhow::Result<()> {
         let xml_conts_x86_64 = include_str!("../../opcodes/x86_64.xml");
         populate_instructions(xml_conts_x86_64)?
             .into_iter()
-            .map(|mut instruction| {
-                instruction.arch = Some(Arch::X86_64);
-                instruction
-            })
             .map(|instruction| {
                 // filter out assemblers by user config
                 instr_filter_targets(&instruction, &target_config)
@@ -133,10 +125,6 @@ pub fn main() -> anyhow::Result<()> {
         let xml_conts_regs_x86 = include_str!("../../registers/x86.xml");
         populate_registers(xml_conts_regs_x86)?
             .into_iter()
-            .map(|mut reg| {
-                reg.arch = Some(Arch::X86);
-                reg
-            })
             .collect()
     } else {
         Vec::new()
@@ -147,10 +135,6 @@ pub fn main() -> anyhow::Result<()> {
         let xml_conts_regs_x86_64 = include_str!("../../registers/x86_64.xml");
         populate_registers(xml_conts_regs_x86_64)?
             .into_iter()
-            .map(|mut reg| {
-                reg.arch = Some(Arch::X86_64);
-                reg
-            })
             .collect()
     } else {
         Vec::new()

--- a/src/types.rs
+++ b/src/types.rs
@@ -304,9 +304,11 @@ pub enum MMXMode {
     MMX,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, EnumString, AsRefStr)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Display, EnumString, AsRefStr)]
 pub enum Arch {
+    #[strum(serialize = "x86")]
     X86,
+    #[strum(serialize = "x86-64")]
     X86_64,
 }
 


### PR DESCRIPTION
This PR moves some of the unrelated work out of #57, as it's already too long to begin with :)

This change has the program read the instruction set information at the top of the xml file and assign the result (`x86` or `x86_64`) to each `Instruction` or `Register` struct  as they're being created, rather than with the additional `map()` calls that are currently in `main()`. This won't have any observable impact on performance (Just a 0.013s average speedup for the time to load all 4 xml files, measured over 10 trials each)/ behavior, but should help to clean things up a bit. :)