### PR TITLE
Update package number in Cargo.toml in prep for 0.7.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asm-lsp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asm-lsp"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Nikos Koukis <nickkouk@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This is the first time I'm doing this, but going off of [this comment](https://github.com/bergercookie/asm-lsp/pull/29#issuecomment-1826858152), I believe all that's required for a new version to be published is for 

- The package number to be updated in `Cargo,toml`
- A new tag to get pushed up