### PR TITLE
Add autocomplete testing framework, tests

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -77,7 +77,7 @@ impl<'own> Instruction {
         self.forms.push(form);
     }
 
-    /// Get the primary name
+    /// Get the primary names
     pub fn get_primary_names(&'own self) -> Vec<&'own str> {
         let mut names = Vec::<&'own str>::new();
         names.push(&self.name);
@@ -88,7 +88,7 @@ impl<'own> Instruction {
         names
     }
 
-    /// get the names of all the associated commands (includes Go and Gas forms)
+    /// Get the names of all the associated commands (includes Go and Gas forms)
     pub fn get_associated_names(&'own self) -> Vec<&'own str> {
         let mut names = Vec::<&'own str>::new();
 


### PR DESCRIPTION
This PR builds off of #83, adding unit tests for the server's autocomplete functionality. The tests cover the following:

* x86/x86_64 instructions
* x86/x86_64 registers
* gas directives
* z80 instructions
* z80 registers

While there are still some features I'd like to add testing for (e.g. view references, goto definition, etc.), with these additions the majority of the server's functionality is covered. As such, I'll count this as "good enough" for now for the unit testing task in #80. 