### PR TITLE
fix: Revert switch to owned data in global maps

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -196,7 +196,7 @@ pub fn text_doc_change_to_ts_edit(
 /// Given a NameTo_SomeItem_ map, returns a `Vec<CompletionItem>` for the items
 /// contained within the map
 pub fn get_completes<T: Completable, U: ArchOrAssembler>(
-    map: &HashMap<(U, String), T>,
+    map: &HashMap<(U, &str), T>,
     kind: Option<CompletionItemKind>,
 ) -> Vec<CompletionItem> {
     map.iter()
@@ -204,7 +204,7 @@ pub fn get_completes<T: Completable, U: ArchOrAssembler>(
             let value = format!("{}", item_info);
 
             CompletionItem {
-                label: name.clone(),
+                label: (*name).to_string(),
                 kind,
                 documentation: Some(Documentation::MarkupContent(MarkupContent {
                     kind: MarkupKind::Markdown,
@@ -219,9 +219,9 @@ pub fn get_completes<T: Completable, U: ArchOrAssembler>(
 pub fn get_hover_resp<T: Hoverable, U: Hoverable, V: Hoverable>(
     word: &str,
     file_word: &str,
-    instruction_map: &HashMap<(Arch, String), T>,
-    register_map: &HashMap<(Arch, String), U>,
-    directive_map: &HashMap<(Assembler, String), V>,
+    instruction_map: &HashMap<(Arch, &str), T>,
+    register_map: &HashMap<(Arch, &str), U>,
+    directive_map: &HashMap<(Assembler, &str), V>,
     include_dirs: &[PathBuf],
 ) -> Option<Hover> {
     let instr_lookup = lookup_hover_resp_by_arch(word, instruction_map);
@@ -254,7 +254,7 @@ pub fn get_hover_resp<T: Hoverable, U: Hoverable, V: Hoverable>(
 
 fn lookup_hover_resp_by_arch<T: Hoverable>(
     word: &str,
-    map: &HashMap<(Arch, String), T>,
+    map: &HashMap<(Arch, &str), T>,
 ) -> Option<Hover> {
     // switch over to vec?
     let (x86_res, x86_64_res, z80_res) = search_for_hoverable_by_arch(word, map);
@@ -291,7 +291,7 @@ fn lookup_hover_resp_by_arch<T: Hoverable>(
 
 fn lookup_hover_resp_by_assembler<T: Hoverable>(
     word: &str,
-    map: &HashMap<(Assembler, String), T>,
+    map: &HashMap<(Assembler, &str), T>,
 ) -> Option<Hover> {
     let (gas_res, go_res) = search_for_hoverable_by_assembler(word, map);
 
@@ -901,21 +901,21 @@ pub fn get_ref_resp(
 // For now, using 'a for both isn't strictly necessary, but fits our use case
 fn search_for_hoverable_by_arch<'a, T: Hoverable>(
     word: &'a str,
-    map: &'a HashMap<(Arch, String), T>,
+    map: &'a HashMap<(Arch, &str), T>,
 ) -> (Option<&'a T>, Option<&'a T>, Option<&'a T>) {
-    let x86_res = map.get(&(Arch::X86, word.to_string()));
-    let x86_64_res = map.get(&(Arch::X86_64, word.to_string()));
-    let z80_res = map.get(&(Arch::Z80, word.to_string()));
+    let x86_res = map.get(&(Arch::X86, word));
+    let x86_64_res = map.get(&(Arch::X86_64, word));
+    let z80_res = map.get(&(Arch::Z80, word));
 
     (x86_res, x86_64_res, z80_res)
 }
 
 fn search_for_hoverable_by_assembler<'a, T: Hoverable>(
     word: &'a str,
-    map: &'a HashMap<(Assembler, String), T>,
+    map: &'a HashMap<(Assembler, &str), T>,
 ) -> (Option<&'a T>, Option<&'a T>) {
-    let gas_res = map.get(&(Assembler::Gas, word.to_string()));
-    let go_res = map.get(&(Assembler::Go, word.to_string()));
+    let gas_res = map.get(&(Assembler::Gas, word));
+    let go_res = map.get(&(Assembler::Go, word));
 
     (gas_res, go_res)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,8 +13,8 @@ pub struct Instruction {
     pub arch: Option<Arch>,
 }
 
-impl Hoverable for Instruction {}
-impl Completable for Instruction {}
+impl Hoverable for &Instruction {}
+impl Completable for &Instruction {}
 
 impl Default for Instruction {
     fn default() -> Self {
@@ -335,8 +335,8 @@ pub struct Directive {
     pub assembler: Option<Assembler>,
 }
 
-impl Hoverable for Directive {}
-impl Completable for Directive {}
+impl Hoverable for &Directive {}
+impl Completable for &Directive {}
 
 impl Default for Directive {
     fn default() -> Self {
@@ -465,8 +465,8 @@ pub struct Register {
     pub url: Option<String>,
 }
 
-impl Hoverable for Register {}
-impl Completable for Register {}
+impl Hoverable for &Register {}
+impl Completable for &Register {}
 
 impl Default for Register {
     fn default() -> Self {
@@ -567,14 +567,16 @@ impl<'own> Register {
 }
 
 // helper structs, types and functions ------------------------------------------------------------
-pub type NameToInstructionMap = HashMap<(Arch, String), Instruction>;
+pub type NameToInstructionMap<'instruction> =
+    HashMap<(Arch, &'instruction str), &'instruction Instruction>;
 
-pub type NameToRegisterMap = HashMap<(Arch, String), Register>;
+pub type NameToRegisterMap<'register> = HashMap<(Arch, &'register str), &'register Register>;
 
-pub type NameToDirectiveMap = HashMap<(Assembler, String), Directive>;
+pub type NameToDirectiveMap<'directive> =
+    HashMap<(Assembler, &'directive str), &'directive Directive>;
 
 // Define a trait for types we display on Hover Requests so we can avoid some duplicate code
-pub trait Hoverable: Display + Clone {}
+pub trait Hoverable: Display + Clone + Copy {}
 // Define a trait for types we display on Completion Requests so we can avoid some duplicate code
 pub trait Completable: Display {}
 // Define a trait for the enums we use to distinguish between different Architectures and Assemblers

--- a/src/x86_parser.rs
+++ b/src/x86_parser.rs
@@ -421,23 +421,23 @@ mod tests {
     }
 }
 
-pub fn populate_name_to_instruction_map(
+pub fn populate_name_to_instruction_map<'instruction>(
     arch: Arch,
-    instructions: &Vec<Instruction>,
-    names_to_instructions: &mut NameToInstructionMap,
+    instructions: &'instruction Vec<Instruction>,
+    names_to_instructions: &mut NameToInstructionMap<'instruction>,
 ) {
     // Add the true names first
     for instruction in instructions {
         for name in &instruction.get_primary_names() {
-            names_to_instructions.insert((arch, name.to_string()), instruction.clone());
+            names_to_instructions.insert((arch, name), instruction);
         }
     }
     // then add alternate form names, being careful not to overwrite existing entries
     for instruction in instructions {
         for name in &instruction.get_associated_names() {
             names_to_instructions
-                .entry((arch, name.to_string()))
-                .or_insert_with(|| instruction.clone());
+                .entry((arch, name))
+                .or_insert_with(|| instruction);
         }
     }
 }
@@ -578,14 +578,14 @@ pub fn populate_registers(xml_contents: &str) -> anyhow::Result<Vec<Register>> {
     Ok(registers_map.into_values().collect())
 }
 
-pub fn populate_name_to_register_map(
+pub fn populate_name_to_register_map<'register>(
     arch: Arch,
-    registers: &Vec<Register>,
-    names_to_registers: &mut NameToRegisterMap,
+    registers: &'register Vec<Register>,
+    names_to_registers: &mut NameToRegisterMap<'register>,
 ) {
     for register in registers {
         for name in &register.get_associated_names() {
-            names_to_registers.insert((arch, name.to_string()), register.clone());
+            names_to_registers.insert((arch, name), register);
         }
     }
 }
@@ -685,14 +685,14 @@ pub fn populate_directives(xml_contents: &str) -> anyhow::Result<Vec<Directive>>
     Ok(directives_map.into_values().collect())
 }
 
-pub fn populate_name_to_directive_map(
+pub fn populate_name_to_directive_map<'directive>(
     assem: Assembler,
-    directives: &Vec<Directive>,
-    names_to_directives: &mut NameToDirectiveMap,
+    directives: &'directive Vec<Directive>,
+    names_to_directives: &mut NameToDirectiveMap<'directive>,
 ) {
     for register in directives {
         for name in &register.get_associated_names() {
-            names_to_directives.insert((assem, name.to_string()), register.clone());
+            names_to_directives.insert((assem, name), register);
         }
     }
 }


### PR DESCRIPTION
This reverts some of the changes I made in #83. In particular, it makes it so that the global maps once again hold references to data in underlying vectors, rather than owning the data themselves for each entry. This won't be an issue for the upcoming serialization changes, as we can still use the vectors, and then populate the hashmaps after deserialization. This should improve our memory footprint, especially as we add new architectures. 

In regards to the testing code, this change slows down the tests considerably, as the global stores have to be initialized on every test. On the upside, however, it improves the error output when a test fails (there's a lot less noise since there's no longer a mutex to poison). 