### PR TITLE
refactor: Extract main loop in handle fns, add timing logs

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,13 +1,16 @@
 use std::path::PathBuf;
 
+use asm_lsp::handle::{
+    handle_completion_request, handle_did_change_text_document_notification,
+    handle_did_open_text_document_notification, handle_document_symbols_request,
+    handle_goto_def_request, handle_hover_request, handle_references_request,
+    handle_signature_help_request,
+};
 use asm_lsp::{
-    get_comp_resp, get_completes, get_document_symbols, get_goto_def_resp, get_hover_resp,
-    get_include_dirs, get_ref_resp, get_sig_help_resp, get_target_config, get_word_from_pos_params,
-    instr_filter_targets, populate_directives, populate_instructions,
-    populate_name_to_directive_map, populate_name_to_instruction_map,
-    populate_name_to_register_map, populate_registers, text_doc_change_to_ts_edit,
-    tree_sitter_logger, Arch, Assembler, NameToDirectiveMap, NameToInstructionMap,
-    NameToRegisterMap,
+    get_completes, get_include_dirs, get_target_config, instr_filter_targets, populate_directives,
+    populate_instructions, populate_name_to_directive_map, populate_name_to_instruction_map,
+    populate_name_to_register_map, populate_registers, tree_sitter_logger, Arch, Assembler,
+    NameToInfoMaps,
 };
 
 use lsp_types::notification::{DidChangeTextDocument, DidOpenTextDocument};
@@ -17,16 +20,15 @@ use lsp_types::request::{
 };
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionOptions, CompletionOptionsCompletionItem,
-    DocumentSymbolResponse, HoverProviderCapability, InitializeParams, OneOf, PositionEncodingKind,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    HoverProviderCapability, InitializeParams, OneOf, PositionEncodingKind, ServerCapabilities,
+    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
     WorkDoneProgressOptions,
 };
 
 use anyhow::Result;
 use log::{error, info};
-use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
+use lsp_server::{Connection, Message, Notification, Request, RequestId};
 use lsp_textdocument::FullTextDocument;
-use serde_json::json;
 
 // main -------------------------------------------------------------------------------------------
 pub fn main() -> Result<()> {
@@ -85,130 +87,182 @@ pub fn main() -> Result<()> {
     let server_capabilities = serde_json::to_value(capabilities).unwrap();
     let initialization_params = connection.initialize(server_capabilities)?;
 
+    let mut names_to_info = NameToInfoMaps::default();
     let params: InitializeParams = serde_json::from_value(initialization_params.clone()).unwrap();
     let target_config = get_target_config(&params);
+    info!("Server Configuration: {:?}", target_config);
 
     // create a map of &Instruction_name -> &Instruction - Use that in user queries
     // The Instruction(s) themselves are stored in a vector and we only keep references to the
     // former map
     let x86_instructions = if target_config.instruction_sets.x86 {
-        info!("Populating instruction set -> x86...");
+        let start = std::time::Instant::now();
         let xml_conts_x86 = include_str!("../../opcodes/x86.xml");
-        populate_instructions(xml_conts_x86)?
+        let instrs = populate_instructions(xml_conts_x86)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
                 instr_filter_targets(&instruction, &target_config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
-            .collect()
+            .collect();
+        info!(
+            "x86 instruction set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        instrs
     } else {
         Vec::new()
     };
 
     let x86_64_instructions = if target_config.instruction_sets.x86_64 {
-        info!("Populating instruction set -> x86_64...");
+        let start = std::time::Instant::now();
         let xml_conts_x86_64 = include_str!("../../opcodes/x86_64.xml");
-        populate_instructions(xml_conts_x86_64)?
+        let instrs = populate_instructions(xml_conts_x86_64)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
                 instr_filter_targets(&instruction, &target_config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
-            .collect()
+            .collect();
+        info!(
+            "z86-64 Instruction set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        instrs
     } else {
         Vec::new()
     };
 
     let z80_instructions = if target_config.instruction_sets.z80 {
-        info!("Populating instruction set -> z80...");
+        let start = std::time::Instant::now();
         let xml_conts_z80 = include_str!("../../opcodes/z80.xml");
-        populate_instructions(xml_conts_z80)?
+        let instrs = populate_instructions(xml_conts_z80)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
                 instr_filter_targets(&instruction, &target_config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
-            .collect()
+            .collect();
+        info!(
+            "z80 instruction set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        instrs
     } else {
         Vec::new()
     };
 
-    let mut names_to_instructions = NameToInstructionMap::new();
-    populate_name_to_instruction_map(Arch::X86, &x86_instructions, &mut names_to_instructions);
+    populate_name_to_instruction_map(
+        Arch::X86,
+        &x86_instructions,
+        &mut names_to_info.instructions,
+    );
     populate_name_to_instruction_map(
         Arch::X86_64,
         &x86_64_instructions,
-        &mut names_to_instructions,
+        &mut names_to_info.instructions,
     );
-    populate_name_to_instruction_map(Arch::Z80, &z80_instructions, &mut names_to_instructions);
+    populate_name_to_instruction_map(
+        Arch::Z80,
+        &z80_instructions,
+        &mut names_to_info.instructions,
+    );
 
     // create a map of &Register_name -> &Register - Use that in user queries
     // The Register(s) themselves are stored in a vector and we only keep references to the
     // former map
     let x86_registers = if target_config.instruction_sets.x86 {
-        info!("Populating register set -> x86...");
+        let start = std::time::Instant::now();
         let xml_conts_regs_x86 = include_str!("../../registers/x86.xml");
-        populate_registers(xml_conts_regs_x86)?
+        let regs = populate_registers(xml_conts_regs_x86)?
             .into_iter()
-            .collect()
+            .collect();
+        info!(
+            "x86 register set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        regs
     } else {
         Vec::new()
     };
 
     let x86_64_registers = if target_config.instruction_sets.x86_64 {
-        info!("Populating register set -> x86_64...");
+        let start = std::time::Instant::now();
         let xml_conts_regs_x86_64 = include_str!("../../registers/x86_64.xml");
-        populate_registers(xml_conts_regs_x86_64)?
+        let regs = populate_registers(xml_conts_regs_x86_64)?
             .into_iter()
-            .collect()
+            .collect();
+        info!(
+            "x86-64 register set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        regs
     } else {
         Vec::new()
     };
 
     let z80_registers = if target_config.instruction_sets.z80 {
-        info!("Populating register set -> z80...");
+        let start = std::time::Instant::now();
         let xml_conts_regs_z80 = include_str!("../../registers/z80.xml");
-        populate_registers(xml_conts_regs_z80)?
+        let regs = populate_registers(xml_conts_regs_z80)?
             .into_iter()
-            .collect()
+            .collect();
+        info!(
+            "z80 register set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        regs
     } else {
         Vec::new()
     };
 
-    let mut names_to_registers = NameToRegisterMap::new();
-    populate_name_to_register_map(Arch::X86, &x86_registers, &mut names_to_registers);
-    populate_name_to_register_map(Arch::X86_64, &x86_64_registers, &mut names_to_registers);
-    populate_name_to_register_map(Arch::Z80, &z80_registers, &mut names_to_registers);
+    populate_name_to_register_map(Arch::X86, &x86_registers, &mut names_to_info.registers);
+    populate_name_to_register_map(
+        Arch::X86_64,
+        &x86_64_registers,
+        &mut names_to_info.registers,
+    );
+    populate_name_to_register_map(Arch::Z80, &z80_registers, &mut names_to_info.registers);
 
     let gas_directives = if target_config.assemblers.gas {
-        info!("Populating directive set -> Gas...");
+        let start = std::time::Instant::now();
         let xml_conts_gas = include_str!("../../directives/gas_directives.xml");
-        populate_directives(xml_conts_gas)?.into_iter().collect()
+        let dirs = populate_directives(xml_conts_gas)?.into_iter().collect();
+        info!(
+            "Gas directive set loaded in {}ms",
+            start.elapsed().as_millis()
+        );
+        dirs
     } else {
         Vec::new()
     };
 
-    let mut names_to_directives = NameToDirectiveMap::new();
-    populate_name_to_directive_map(Assembler::Gas, &gas_directives, &mut names_to_directives);
+    populate_name_to_directive_map(
+        Assembler::Gas,
+        &gas_directives,
+        &mut names_to_info.directives,
+    );
 
-    let instr_completion_items =
-        get_completes(&names_to_instructions, Some(CompletionItemKind::OPERATOR));
+    let instr_completion_items = get_completes(
+        &names_to_info.instructions,
+        Some(CompletionItemKind::OPERATOR),
+    );
     let reg_completion_items =
-        get_completes(&names_to_registers, Some(CompletionItemKind::VARIABLE));
-    let directive_completion_items =
-        get_completes(&names_to_directives, Some(CompletionItemKind::OPERATOR));
+        get_completes(&names_to_info.registers, Some(CompletionItemKind::VARIABLE));
+    let directive_completion_items = get_completes(
+        &names_to_info.directives,
+        Some(CompletionItemKind::OPERATOR),
+    );
 
     let include_dirs = get_include_dirs();
 
     main_loop(
         &connection,
         initialization_params,
-        &names_to_instructions,
-        &names_to_directives,
-        &names_to_registers,
+        &names_to_info,
         &instr_completion_items,
         &directive_completion_items,
         &reg_completion_items,
@@ -216,18 +270,14 @@ pub fn main() -> Result<()> {
     )?;
     io_threads.join()?;
 
-    // Shut down gracefully.
     info!("Shutting down asm_lsp");
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn main_loop(
     connection: &Connection,
     params: serde_json::Value,
-    names_to_instructions: &NameToInstructionMap,
-    names_to_directives: &NameToDirectiveMap,
-    names_to_registers: &NameToRegisterMap,
+    names_to_info: &NameToInfoMaps,
     instruction_completion_items: &[CompletionItem],
     directive_completion_items: &[CompletionItem],
     register_completion_items: &[CompletionItem],
@@ -240,210 +290,118 @@ fn main_loop(
     parser.set_logger(Some(Box::new(tree_sitter_logger)));
     parser.set_language(tree_sitter_asm::language())?;
 
-    let mut empty_resp = Response {
-        id: RequestId::from(0),
-        result: Some(json!("")),
-        error: None,
-    };
-
     info!("Starting asm_lsp loop...");
     for msg in &connection.receiver {
+        let start = std::time::Instant::now();
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req)? {
+                    info!("Shutting down asm_lsp");
                     return Ok(());
                 } else if let Ok((id, params)) = cast_req::<HoverRequest>(req.clone()) {
-                    // HoverRequest ---------------------------------------------------------------
-                    let (word, file_word) = if let Some(ref doc) = curr_doc {
-                        (
-                            // get the word under the cursor
-                            get_word_from_pos_params(
-                                doc,
-                                &params.text_document_position_params,
-                                "",
-                            ),
-                            // treat the word under the cursor as a filename and grab it as well
-                            get_word_from_pos_params(
-                                doc,
-                                &params.text_document_position_params,
-                                ".",
-                            ),
-                        )
-                    } else {
-                        continue;
-                    };
-
-                    // get documentation ------------------------------------------------------
-                    // format response
-                    let hover_resp = get_hover_resp(
-                        word,
-                        file_word,
-                        names_to_instructions,
-                        names_to_registers,
-                        names_to_directives,
+                    handle_hover_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        names_to_info,
                         include_dirs,
+                    )?;
+                    info!(
+                        "Hover request serviced in {}ms",
+                        start.elapsed().as_millis()
                     );
-                    if hover_resp.is_some() {
-                        let result = serde_json::to_value(&hover_resp).unwrap();
-                        let result = Response {
-                            id: id.clone(),
-                            result: Some(result),
-                            error: None,
-                        };
-                        connection.sender.send(Message::Response(result))?;
-                    } else {
-                        empty_resp.id = id.clone();
-                        connection
-                            .sender
-                            .send(Message::Response(empty_resp.clone()))?;
-                    }
                 } else if let Ok((id, params)) = cast_req::<Completion>(req.clone()) {
-                    // CompletionRequest ---------------------------------------------------------------
-                    // get suggestions ------------------------------------------------------
-                    if let Some(ref doc) = curr_doc {
-                        let comp_resp = get_comp_resp(
-                            doc.get_content(None),
-                            &mut parser,
-                            &mut tree,
-                            &params,
-                            instruction_completion_items,
-                            directive_completion_items,
-                            register_completion_items,
-                        );
-                        if comp_resp.is_some() {
-                            let result = serde_json::to_value(&comp_resp).unwrap();
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result))?;
-                            continue;
-                        }
-                    }
-                    empty_resp.id = id.clone();
-                    connection
-                        .sender
-                        .send(Message::Response(empty_resp.clone()))?;
+                    handle_completion_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        &mut parser,
+                        &mut tree,
+                        instruction_completion_items,
+                        directive_completion_items,
+                        register_completion_items,
+                    )?;
+                    info!(
+                        "Completion request serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok((id, params)) = cast_req::<GotoDefinition>(req.clone()) {
-                    if let Some(ref doc) = curr_doc {
-                        let def_resp = get_goto_def_resp(doc, &mut parser, &mut tree, &params);
-                        if def_resp.is_some() {
-                            let result = serde_json::to_value(&def_resp).unwrap();
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result))?;
-                        } else {
-                            empty_resp.id = id.clone();
-                            connection
-                                .sender
-                                .send(Message::Response(empty_resp.clone()))?;
-                        }
-                    }
+                    handle_goto_def_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        &mut parser,
+                        &mut tree,
+                    )?;
+                    info!(
+                        "Goto definition request serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok((id, params)) = cast_req::<DocumentSymbolRequest>(req.clone()) {
-                    // DocumentSymbolRequest ---------------------------------------------------------------
-                    if let Some(ref doc) = curr_doc {
-                        let symbols = get_document_symbols(
-                            doc.get_content(None),
-                            &mut parser,
-                            &mut tree,
-                            &params,
-                        );
-                        if let Some(symbols) = symbols {
-                            let resp = DocumentSymbolResponse::Nested(symbols);
-                            let result = serde_json::to_value(&resp).unwrap();
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result))?;
-                            continue;
-                        }
-                    }
-                    empty_resp.id = id.clone();
-                    connection
-                        .sender
-                        .send(Message::Response(empty_resp.clone()))?;
+                    handle_document_symbols_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        &mut parser,
+                        &mut tree,
+                    )?;
+                    info!(
+                        "Document symbols request serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok((id, params)) = cast_req::<SignatureHelpRequest>(req.clone()) {
-                    // SignatureHelp ---------------------------------------------------------------
-                    if let Some(ref doc) = curr_doc {
-                        let sig_resp = get_sig_help_resp(
-                            doc.get_content(None),
-                            &mut parser,
-                            &params,
-                            &mut tree,
-                            names_to_instructions,
-                        );
-
-                        if let Some(sig) = sig_resp {
-                            let result = serde_json::to_value(&sig).unwrap();
-
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result.clone()))?;
-                            continue;
-                        }
-                    }
-                    empty_resp.id = id.clone();
-                    connection
-                        .sender
-                        .send(Message::Response(empty_resp.clone()))?;
+                    handle_signature_help_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        &mut parser,
+                        &mut tree,
+                        &names_to_info.instructions,
+                    )?;
+                    info!(
+                        "Signature help request serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok((id, params)) = cast_req::<References>(req.clone()) {
-                    if let Some(ref doc) = curr_doc {
-                        let ref_resp = get_ref_resp(doc, &mut parser, &mut tree, &params);
-                        if !ref_resp.is_empty() {
-                            let result = serde_json::to_value(&ref_resp).unwrap();
-
-                            let result = Response {
-                                id: id.clone(),
-                                result: Some(result),
-                                error: None,
-                            };
-                            connection.sender.send(Message::Response(result.clone()))?;
-                            continue;
-                        }
-                    }
-                    empty_resp.id = id.clone();
-                    connection
-                        .sender
-                        .send(Message::Response(empty_resp.clone()))?;
+                    handle_references_request(
+                        connection,
+                        id,
+                        &params,
+                        &curr_doc,
+                        &mut parser,
+                        &mut tree,
+                    )?;
+                    info!(
+                        "References request serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else {
                     error!("Invalid request format -> {:#?}", req);
                 }
             }
             Message::Notification(notif) => {
                 if let Ok(params) = cast_notif::<DidOpenTextDocument>(notif.clone()) {
-                    curr_doc = Some(FullTextDocument::new(
-                        params.text_document.language_id.clone(),
-                        params.text_document.version,
-                        params.text_document.text.clone(),
-                    ));
-                    tree = parser.parse(params.text_document.text, None);
+                    handle_did_open_text_document_notification(
+                        params,
+                        &mut curr_doc,
+                        &mut parser,
+                        &mut tree,
+                    );
+                    info!(
+                        "Did open text document notification serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok(params) = cast_notif::<DidChangeTextDocument>(notif.clone()) {
-                    if let Some(ref mut doc) = curr_doc {
-                        // Sync our in-memory copy of the current buffer
-                        doc.update(&params.content_changes, params.text_document.version);
-                        // Update the TS tree
-                        if let Some(ref mut curr_tree) = tree {
-                            for change in &params.content_changes {
-                                match text_doc_change_to_ts_edit(change, doc) {
-                                    Ok(edit) => {
-                                        curr_tree.edit(&edit);
-                                    }
-                                    Err(e) => {
-                                        error!("Bad edit info, failed to edit tree - Error: {e}");
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    handle_did_change_text_document_notification(
+                        &params,
+                        &mut curr_doc,
+                        &mut tree,
+                    )?;
                 }
             }
             Message::Response(_resp) => {}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,0 +1,350 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use lsp_server::{Connection, Message, RequestId, Response};
+use lsp_textdocument::FullTextDocument;
+use lsp_types::{
+    CompletionItem, CompletionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
+    DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams, HoverParams,
+    ReferenceParams, SignatureHelpParams,
+};
+use serde_json::json;
+use tree_sitter::{Parser, Tree};
+
+use crate::{
+    get_comp_resp, get_document_symbols, get_goto_def_resp, get_hover_resp, get_ref_resp,
+    get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit, NameToInfoMaps,
+    NameToInstructionMap,
+};
+
+/// Handles hover requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_hover_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &HoverParams,
+    curr_doc: &Option<FullTextDocument>,
+    names_to_info: &NameToInfoMaps,
+    include_dirs: &[PathBuf],
+) -> Result<()> {
+    let empty_resp = Response {
+        id: id.clone(),
+        result: Some(json!("")),
+        error: None,
+    };
+
+    let (word, file_word) = if let Some(ref doc) = curr_doc {
+        (
+            // get the word under the cursor
+            get_word_from_pos_params(doc, &params.text_document_position_params, ""),
+            // treat the word under the cursor as a filename and grab it as well
+            get_word_from_pos_params(doc, &params.text_document_position_params, "."),
+        )
+    } else {
+        return Ok(connection
+            .sender
+            .send(Message::Response(empty_resp.clone()))?);
+    };
+
+    if let Some(hover_resp) = get_hover_resp(
+        word,
+        file_word,
+        &names_to_info.instructions,
+        &names_to_info.registers,
+        &names_to_info.directives,
+        include_dirs,
+    ) {
+        let result = serde_json::to_value(hover_resp).unwrap();
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
+        return Ok(connection.sender.send(Message::Response(result))?);
+    }
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles completion requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+#[allow(clippy::too_many_arguments)]
+pub fn handle_completion_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &CompletionParams,
+    curr_doc: &Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+    instruction_completion_items: &[CompletionItem],
+    directive_completion_items: &[CompletionItem],
+    register_completion_items: &[CompletionItem],
+) -> Result<()> {
+    if let Some(ref doc) = curr_doc {
+        if let Some(comp_resp) = get_comp_resp(
+            doc.get_content(None),
+            parser,
+            tree,
+            params,
+            instruction_completion_items,
+            directive_completion_items,
+            register_completion_items,
+        ) {
+            let result = serde_json::to_value(comp_resp).unwrap();
+            let result = Response {
+                id,
+                result: Some(result),
+                error: None,
+            };
+            return Ok(connection.sender.send(Message::Response(result))?);
+        }
+    }
+
+    let empty_resp = Response {
+        id,
+        result: Some(json!("")),
+        error: None,
+    };
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles go to definition requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_goto_def_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &GotoDefinitionParams,
+    curr_doc: &Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+) -> Result<()> {
+    if let Some(ref doc) = curr_doc {
+        if let Some(def_resp) = get_goto_def_resp(doc, parser, tree, params) {
+            let result = serde_json::to_value(def_resp).unwrap();
+            let result = Response {
+                id,
+                result: Some(result),
+                error: None,
+            };
+
+            return Ok(connection.sender.send(Message::Response(result))?);
+        }
+    }
+
+    let empty_resp = Response {
+        id,
+        result: Some(json!("")),
+        error: None,
+    };
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles document symbols requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_document_symbols_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &DocumentSymbolParams,
+    curr_doc: &Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+) -> Result<()> {
+    if let Some(ref doc) = curr_doc {
+        if let Some(symbols) = get_document_symbols(doc.get_content(None), parser, tree, params) {
+            let resp = DocumentSymbolResponse::Nested(symbols);
+            let result = serde_json::to_value(resp).unwrap();
+            let result = Response {
+                id: id.clone(),
+                result: Some(result),
+                error: None,
+            };
+            return Ok(connection.sender.send(Message::Response(result))?);
+        }
+    }
+
+    let empty_resp = Response {
+        id,
+        result: Some(json!("")),
+        error: None,
+    };
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles signature help requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_signature_help_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &SignatureHelpParams,
+    curr_doc: &Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+    names_to_instructions: &NameToInstructionMap,
+) -> Result<()> {
+    if let Some(ref doc) = curr_doc {
+        let sig_resp = get_sig_help_resp(
+            doc.get_content(None),
+            parser,
+            params,
+            tree,
+            names_to_instructions,
+        );
+
+        if let Some(sig) = sig_resp {
+            let result = serde_json::to_value(sig).unwrap();
+            let result = Response {
+                id: id.clone(),
+                result: Some(result),
+                error: None,
+            };
+
+            return Ok(connection.sender.send(Message::Response(result))?);
+        }
+    }
+
+    let empty_resp = Response {
+        id,
+        result: Some(json!("")),
+        error: None,
+    };
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles reference requests
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_references_request(
+    connection: &Connection,
+    id: RequestId,
+    params: &ReferenceParams,
+    curr_doc: &Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+) -> Result<()> {
+    if let Some(ref doc) = curr_doc {
+        let ref_resp = get_ref_resp(doc, parser, tree, params);
+        if !ref_resp.is_empty() {
+            let result = serde_json::to_value(&ref_resp).unwrap();
+
+            let result = Response {
+                id: id.clone(),
+                result: Some(result),
+                error: None,
+            };
+            return Ok(connection.sender.send(Message::Response(result.clone()))?);
+        }
+    }
+
+    let empty_resp = Response {
+        id,
+        result: Some(json!("")),
+        error: None,
+    };
+
+    Ok(connection.sender.send(Message::Response(empty_resp))?)
+}
+
+/// Handles did open text document notifications
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_did_open_text_document_notification(
+    params: DidOpenTextDocumentParams,
+    curr_doc: &mut Option<FullTextDocument>,
+    parser: &mut Parser,
+    tree: &mut Option<Tree>,
+) {
+    *curr_doc = Some(FullTextDocument::new(
+        params.text_document.language_id,
+        params.text_document.version,
+        params.text_document.text.clone(),
+    ));
+    *tree = parser.parse(params.text_document.text, None);
+}
+
+/// Handles did change text document notifications
+/// Edits are applied to `curr_doc` and `tree`, but `tree` is not
+/// re-parsed
+///
+/// # Errors
+///
+/// Returns 'Err' if the response fails to send via `connection`
+///
+/// # Panics
+///
+/// Panics if JSON encoding of a response fails
+pub fn handle_did_change_text_document_notification(
+    params: &DidChangeTextDocumentParams,
+    curr_doc: &mut Option<FullTextDocument>,
+    tree: &mut Option<Tree>,
+) -> Result<()> {
+    if let Some(ref mut doc) = curr_doc {
+        // Sync our in-memory copy of the current buffer
+        doc.update(&params.content_changes, params.text_document.version);
+        // Update the TS tree
+        if let Some(ref mut curr_tree) = tree {
+            for change in &params.content_changes {
+                match text_doc_change_to_ts_edit(change, doc) {
+                    Ok(edit) => {
+                        curr_tree.edit(&edit);
+                    }
+                    Err(e) => {
+                        return Err(anyhow!("Bad edit info, failed to edit tree - Error: {e}"));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod handle;
 pub mod lsp;
 mod test;
 pub mod types;

--- a/src/types.rs
+++ b/src/types.rs
@@ -572,6 +572,13 @@ impl<'own> Register {
 }
 
 // helper structs, types and functions ------------------------------------------------------------
+#[derive(Debug, Clone, Default)]
+pub struct NameToInfoMaps<'a> {
+    pub instructions: NameToInstructionMap<'a>,
+    pub registers: NameToRegisterMap<'a>,
+    pub directives: NameToDirectiveMap<'a>,
+}
+
 pub type NameToInstructionMap<'instruction> =
     HashMap<(Arch, &'instruction str), &'instruction Instruction>;
 


### PR DESCRIPTION
This PR continues the refactor/ cleanup from #87 by pulling most of the logic out of the main loop and into various handler functions (inside the new `src/handle.rs` file). Additionally, this also adds timing logs for each request and notification, as mentioned in #80.