### PR TITLE
fix: remove path restrictions for ci test runs

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -6,17 +6,8 @@ on:
   push:
     branches:
       - "*"
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - build.rs
   pull_request:
     branches: ["master"]
-    paths:
-      - ".github/workflows/tests.yml"
-      - "src/**"
-      - "Cargo.*"
-      - build.rs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}


### PR DESCRIPTION
This change to the github workflows fixes the issue where workflows won't trigger if a source file isn't modified, e.g. when `README.md` is updated. This has been an issue in a few PRs, most recently in #79. Given that changes to the data files (anything in `registers`, `opcodes`, or `directives` currently) can change behavior in the executable, I think it makes more sense anyway to just run the entire test suite on any change to the repo.