### PR TITLE
feat: Support multiple documents, other misc. changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,9 +821,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lsp-server"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52dccdf3302eefab8c8a1273047f0a3c3dca4b527c8458d00c09484c8371928"
+checksum = "248f65b78f6db5d8e1b1604b4098a28b43d21a8eb1deeca22b1c421b276c7095"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -825,8 +834,7 @@ dependencies = [
 [[package]]
 name = "lsp-textdocument"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dcaf776a57a63c3baafa3ab0ae25943049865c862980522a5112b1fd849503"
+source = "git+https://github.com/GiveMe-A-Name/lsp-textdocument.git?rev=02ecef14aeda0c8330d39fc4ce5242b2de77c509#02ecef14aeda0c8330d39fc4ce5242b2de77c509"
 dependencies = [
  "lsp-types",
  "serde_json",
@@ -834,15 +842,15 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -1917,7 +1925,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ publish = true
 exclude = ["samples/*", "demo/*"]
 license = "BSD-2-Clause"
 
+[lints.clippy]
+# Using the URI type to identify open files is kind of unavoidable, tell clippy everything's gonna be ok
+mutable_key_type = "allow"
+
 [lib]
 name = "asm_lsp"
 path = "src/lib.rs"
@@ -30,8 +34,8 @@ anyhow = "1.0.70"
 # write to stderr instead of stdout
 flexi_logger = "0.25.3"
 log = { version = "0.4.17" }
-lsp-server = "0.7.0"
-lsp-types = "0.94.0"
+lsp-server = "0.7.6"
+lsp-types = "0.97.0"
 regex = "1.7.2"
 reqwest = { version = "0.11.15", features = ["blocking"] }
 strum = "0.24.1"
@@ -43,7 +47,7 @@ home = "0.5.5"
 tree-sitter = "0.20.10"
 tree-sitter-asm = "0.1.0"
 once_cell = "1.18.0"
-lsp-textdocument = "0.3.2"
+lsp-textdocument = { git = "https://github.com/GiveMe-A-Name/lsp-textdocument.git", rev = "02ecef14aeda0c8330d39fc4ce5242b2de77c509" }
 dirs = "5.0.1"
 symbolic = { version = "12.8.0", features = ["demangle"] }
 symbolic-demangle = "12.8.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -367,7 +367,7 @@ fn main_loop(
                     error!("Invalid request format -> {:#?}", req);
                 }
             }
-            Message::Notification(ref notif) => {
+            Message::Notification(notif) => {
                 if let Ok(params) = cast_notif::<DidOpenTextDocument>(notif.clone()) {
                     handle_did_open_text_document_notification(
                         &params,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use lsp_types::Url;
+use lsp_types::Uri;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumString};
 use tree_sitter::{Parser, Tree};
@@ -1055,4 +1055,5 @@ pub struct TreeEntry {
     pub parser: Parser,
 }
 
-pub type TreeStore = BTreeMap<Url, TreeEntry>;
+/// Associates URIs with their corresponding tree-sitter tree and parser
+pub type TreeStore = BTreeMap<Uri, TreeEntry>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,13 @@
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
+    str::FromStr,
+};
 
+use lsp_types::Url;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumString};
+use tree_sitter::{Parser, Tree};
 
 // Instruction ------------------------------------------------------------------------------------
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -1042,3 +1048,11 @@ pub enum OperandType {
 
 /// Represents a text cursor between characters, pointing at the next character in the buffer.
 pub type Column = usize;
+
+/// Stores a tree-sitter tree and it associated parser for a given source file
+pub struct TreeEntry {
+    pub tree: Option<Tree>,
+    pub parser: Parser,
+}
+
+pub type TreeStore = BTreeMap<Url, TreeEntry>;


### PR DESCRIPTION
This PR does a few things

* Supports multiple documents at once
    - Done in prep for supporting compile_commands.json (see #77, #85)
    - This is also just a good idea in and of itself
* Upgrade the [lsp-textdocument](https://github.com/GiveMe-A-Name/lsp-textdocument/tree/main) dependency
    - This eliminates a versioning conflict, allowing us to alos upgrade the [lsp-types](https://github.com/gluon-lang/lsp-types) dependency. With the `Hash` trait derived for the `Location` struct in https://github.com/gluon-lang/lsp-types/pull/279, we can now clean up some logic [around here](https://github.com/bergercookie/asm-lsp/blob/97b473e409ded1953f6e6baf1853e48b60e31ab3/src/lsp.rs#L885) in a follow-up PR as well