### PR TITLE
feat: Support compile_commands.json/compile_flags.txt, correct include directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ version = "0.7.1"
 dependencies = [
  "anyhow",
  "bincode",
+ "compile_commands",
  "dirs",
  "flexi_logger",
  "home",
@@ -210,6 +211,16 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys",
+]
+
+[[package]]
+name = "compile_commands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d05c707e1d0f610edfb30523e2d654d1779b58db656191630026ddaca2a6dd3"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -484,7 +495,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -833,8 +844,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-textdocument"
-version = "0.3.2"
-source = "git+https://github.com/GiveMe-A-Name/lsp-textdocument.git?rev=02ecef14aeda0c8330d39fc4ce5242b2de77c509#02ecef14aeda0c8330d39fc4ce5242b2de77c509"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dc223af95101fe950a871d4d567b6f98a1ecfcee5861f4b57644581aaa980d"
 dependencies = [
  "lsp-types",
  "serde_json",
@@ -1047,7 +1059,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1175,9 +1187,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1193,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1391,7 +1403,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1425,29 +1437,29 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -1462,7 +1474,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1678,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1738,7 +1750,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1783,7 +1795,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1984,7 +1996,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
 
@@ -2018,7 +2030,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,14 @@ home = "0.5.5"
 tree-sitter = "0.20.10"
 tree-sitter-asm = "0.1.0"
 once_cell = "1.18.0"
-lsp-textdocument = { git = "https://github.com/GiveMe-A-Name/lsp-textdocument.git", rev = "02ecef14aeda0c8330d39fc4ce5242b2de77c509" }
 dirs = "5.0.1"
 symbolic = { version = "12.8.0", features = ["demangle"] }
 symbolic-demangle = "12.8.0"
 url-escape = "0.1.1"
 quick-xml = "0.35.0"
 bincode = "1.3.3"
+lsp-textdocument = "0.4.0"
+compile_commands = "0.2.0"
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{anyhow, Result};
+use compile_commands::SourceFile;
 use lsp_server::{Connection, Message, RequestId, Response};
 use lsp_textdocument::TextDocuments;
 use lsp_types::{
@@ -35,7 +36,7 @@ pub fn handle_hover_request(
     params: &HoverParams,
     text_store: &TextDocuments,
     names_to_info: &NameToInfoMaps,
-    include_dirs: &[PathBuf],
+    include_dirs: &HashMap<SourceFile, Vec<PathBuf>>,
 ) -> Result<()> {
     let empty_resp = Response {
         id: id.clone(),
@@ -59,6 +60,7 @@ pub fn handle_hover_request(
     };
 
     if let Some(hover_resp) = get_hover_resp(
+        params,
         word,
         file_word,
         &names_to_info.instructions,

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,8 +7,9 @@ mod tests {
     use lsp_textdocument::FullTextDocument;
     use lsp_types::{
         CompletionContext, CompletionItem, CompletionItemKind, CompletionParams,
-        CompletionTriggerKind, HoverContents, MarkupContent, MarkupKind, PartialResultParams,
-        Position, TextDocumentIdentifier, TextDocumentPositionParams, Uri, WorkDoneProgressParams,
+        CompletionTriggerKind, HoverContents, HoverParams, MarkupContent, MarkupKind,
+        PartialResultParams, Position, TextDocumentIdentifier, TextDocumentPositionParams, Uri,
+        WorkDoneProgressParams,
     };
     use tree_sitter::Parser;
 
@@ -243,6 +244,13 @@ mod tests {
             position: position.expect("No <cursor> marker found"),
         };
 
+        let hover_params = HoverParams {
+            text_document_position_params: pos_params.clone(),
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        };
+
         let (word, file_word) = if let Some(ref doc) = curr_doc {
             (
                 // get the word under the cursor
@@ -255,12 +263,13 @@ mod tests {
         };
 
         let resp = get_hover_resp(
+            &hover_params,
             &word,
             &file_word,
             &globals.names_to_instructions,
             &globals.names_to_registers,
             &globals.names_to_directives,
-            &Vec::new(),
+            &HashMap::new(),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR adds support for the LLVM project's `compile_commands.json` and `compile_flags.txt` [standards](https://clang.llvm.org/docs/JSONCompilationDatabase.html). I created a [separate crate](https://github.com/WillLillis/compile_commands) to provide a wrapper type around the formats, which the server then depends on. 

The standard allows for a compile command to be associated with a given source file. From this command, we can extract additional include directories. In addition to searching default include directories (as before), the server will now check for additional include directories, respecting the source file a request was made in. This checks off another item from #80, and moves us one step closer to #85.


Closes #77 