### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asm-lsp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asm-lsp"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Nikos Koukis <nickkouk@gmail.com>"]
 edition = "2018"
 
@@ -12,7 +12,7 @@ repository = "https://github.com/bergercookie/asm-lsp"
 
 readme = "README.md"
 
-keywords = ["assembly", "language-server", "lsp", "tooling", "x86", "x86-64", "z80"]
+keywords = ["assembly", "language-server", "lsp", "tooling", "x86"]
 categories = ["command-line-utilities", "development-tools"]
 publish = true
 exclude = ["samples/*", "demo/*"]


### PR DESCRIPTION
Continuation of #99, as publishing failed due to too many keywords in the Cargo.toml file.