### PR TITLE
feat: label autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,8 +1894,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-asm"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc74797a3118e3f8b440d58b341a7c1d4538e26ddfa1b4254129a0f1280b94"
+source = "git+https://github.com/RubixDev/tree-sitter-asm#b0306e9bb2ebe01c6562f1aef265cc42ccc53070"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ serde = "1.0.158"
 toml = "0.8.1"
 home = "0.5.5"
 tree-sitter = "0.20.10"
-tree-sitter-asm = "0.1.0"
 once_cell = "1.18.0"
 dirs = "5.0.1"
 symbolic = { version = "12.8.0", features = ["demangle"] }
@@ -55,6 +54,7 @@ quick-xml = "0.35.0"
 bincode = "1.3.3"
 lsp-textdocument = "0.4.0"
 compile_commands = "0.2.0"
+tree-sitter-asm = { git = "https://github.com/RubixDev/tree-sitter-asm" }
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/src/test.rs
+++ b/src/test.rs
@@ -388,6 +388,30 @@ mod tests {
         test_autocomplete(source, expected_kind, trigger_kind, trigger_character);
     }
 
+    fn test_label_autocomplete(
+        source: &str,
+        trigger_kind: CompletionTriggerKind,
+        trigger_character: Option<String>,
+    ) {
+        let expected_kind = CompletionItemKind::VARIABLE;
+        test_autocomplete(source, expected_kind, trigger_kind, trigger_character);
+    }
+
+    #[test]
+    fn handle_autocomplete_it_provides_label_comps_as_instruction_arg() {
+        test_label_autocomplete(
+            r#"
+foo:
+        mov eax, 0
+
+bar:
+        call f<cursor>
+            "#,
+            CompletionTriggerKind::INVOKED,
+            None,
+        );
+    }
+
     #[test]
     fn handle_autocomplete_x86_x86_64_it_provides_instr_comps_one_character_start() {
         test_instruction_autocomplete("s<cursor>", CompletionTriggerKind::INVOKED, None);


### PR DESCRIPTION
Implements basic autocomplete for labels. There is a minor performance concern here, as we're running a tree-sitter query over the entire document for every autocomplete request that isn't initiated by a trigger character. If this proves to be too much of a slow down, I can look into speeding it up and/or putting this feature behind a configuration flag.

Quick demo using the example from #104:

![label_autocomplete](https://github.com/user-attachments/assets/a9a30ce5-52a5-4c0a-971d-c82d30729fd9)

This PR also bumps [tree-sitter-asm](https://github.com/RubixDev/tree-sitter-asm) to its current latest commit, rather than the older 0.1.0 release. There's been some nice improvements there lately and all of the project's tests still pass with the updates!

cc @ChillerDragon

Closes #104 