### PR TITLE
chore: bump version to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asm-lsp"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asm-lsp"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Nikos Koukis <nickkouk@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Bumps the version for a 0.7.4 release.

Includes some bug fixes, label autocomplete feature, and dependency bumps. 