### PR TITLE
revert to tree-sitter 0.1.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,7 +1897,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-asm"
 version = "0.1.0"
-source = "git+https://github.com/RubixDev/tree-sitter-asm#b0306e9bb2ebe01c6562f1aef265cc42ccc53070"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc74797a3118e3f8b440d58b341a7c1d4538e26ddfa1b4254129a0f1280b94"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ quick-xml = "0.35.0"
 bincode = "1.3.3"
 lsp-textdocument = "0.4.0"
 compile_commands = "0.2.0"
-tree-sitter-asm = { git = "https://github.com/RubixDev/tree-sitter-asm" }
+tree-sitter-asm = "0.1.0"
 
 [dev-dependencies]
 mockito = "1.2.0"


### PR DESCRIPTION
Turns out you can't publish to crates.io with a git dependency...
This reverts the change for `tree-sitter-asm` from its latest git commit to 0.1.0.