### PR TITLE
fix: Return None on failure to find definition

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -167,7 +167,7 @@ pub fn handle_goto_def_request(
 
     let empty_resp = Response {
         id,
-        result: Some(json!("")),
+        result: None,
         error: None,
     };
 


### PR DESCRIPTION
Returning an empty string in response to this requests causes neovim to display an error. See screenshot below (extracted from @ChillerDragon's report in #105):

![image](https://github.com/user-attachments/assets/57f8c223-c462-489f-bb61-ec5d711e6d03)

Returning `None` instead fixes this.