### PR TITLE
fix: Bump tree-sitter, tree-sitter-asm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
 dependencies = [
  "cc",
  "regex",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-asm"
-version = "0.1.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc74797a3118e3f8b440d58b341a7c1d4538e26ddfa1b4254129a0f1280b94"
+checksum = "af70c4c362b4dca989cb46eab0af6cb70c7d7aa1b11d5526137b9d16faa7b0bf"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1.0.94"
 serde = "1.0.158"
 toml = "0.8.1"
 home = "0.5.5"
-tree-sitter = "0.20.10"
 once_cell = "1.18.0"
 dirs = "5.0.1"
 symbolic = { version = "12.8.0", features = ["demangle"] }
@@ -54,7 +53,8 @@ quick-xml = "0.35.0"
 bincode = "1.3.3"
 lsp-textdocument = "0.4.0"
 compile_commands = "0.2.0"
-tree-sitter-asm = "0.1.0"
+tree-sitter = "0.22.6"
+tree-sitter-asm = "0.22.6"
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -407,6 +407,10 @@ fn main_loop(
                         &mut text_store,
                         &mut tree_store,
                     )?;
+                    info!(
+                        "Did change text document notification serviced in {}ms",
+                        start.elapsed().as_millis()
+                    );
                 } else if let Ok(params) = cast_notif::<DidCloseTextDocument>(notif.clone()) {
                     handle_did_close_text_document_notification(
                         &params,

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -374,7 +374,7 @@ pub fn handle_did_open_text_document_notification(
     text_store.listen(DidOpenTextDocument::METHOD, &raw_params);
 
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_asm::language()).unwrap();
+    parser.set_language(&tree_sitter_asm::language()).unwrap();
     tree_store.insert(
         params.text_document.uri.clone(),
         TreeEntry {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -743,7 +743,7 @@ pub fn get_comp_resp(
 
         static QUERY_DIRECTIVE: Lazy<tree_sitter::Query> = Lazy::new(|| {
             tree_sitter::Query::new(
-                tree_sitter_asm::language(),
+                &tree_sitter_asm::language(),
                 "(meta kind: (meta_ident) @directive)",
             )
             .unwrap()
@@ -772,7 +772,7 @@ pub fn get_comp_resp(
         // need a separate cursor to search the entire document
         let mut doc_cursor = tree_sitter::QueryCursor::new();
         static QUERY_LABEL: Lazy<tree_sitter::Query> = Lazy::new(|| {
-            tree_sitter::Query::new(tree_sitter_asm::language(), "(label (ident) @label)").unwrap()
+            tree_sitter::Query::new(&tree_sitter_asm::language(), "(label (ident) @label)").unwrap()
         });
         let captures = doc_cursor.captures(&QUERY_LABEL, tree.root_node(), curr_doc);
         let mut labels = HashSet::new();
@@ -787,7 +787,7 @@ pub fn get_comp_resp(
 
         static QUERY_INSTR_ANY: Lazy<tree_sitter::Query> = Lazy::new(|| {
             tree_sitter::Query::new(
-                tree_sitter_asm::language(),
+                &tree_sitter_asm::language(),
                 "[
                     (instruction kind: (word) @instr_name)
                     (
@@ -979,7 +979,7 @@ pub fn get_sig_help_resp(
         // Instruction with any (including zero) argument(s)
         static QUERY_INSTR_ANY_ARGS: Lazy<tree_sitter::Query> = Lazy::new(|| {
             tree_sitter::Query::new(
-                tree_sitter_asm::language(),
+                &tree_sitter_asm::language(),
                 "(instruction kind: (word) @instr_name)",
             )
             .unwrap()
@@ -1086,7 +1086,7 @@ pub fn get_goto_def_resp(
 
     if let Some(ref tree) = tree_entry.tree {
         static QUERY_LABEL: Lazy<tree_sitter::Query> = Lazy::new(|| {
-            tree_sitter::Query::new(tree_sitter_asm::language(), "(label) @label").unwrap()
+            tree_sitter::Query::new(&tree_sitter_asm::language(), "(label) @label").unwrap()
         });
 
         let is_not_ident_char = |c: char| !(c.is_alphanumeric() || c == '_');
@@ -1138,14 +1138,14 @@ pub fn get_ref_resp(
     if let Some(ref tree) = tree_entry.tree {
         static QUERY_LABEL: Lazy<tree_sitter::Query> = Lazy::new(|| {
             tree_sitter::Query::new(
-                tree_sitter_asm::language(),
+                &tree_sitter_asm::language(),
                 "(label (ident (reg (word)))) @label",
             )
             .unwrap()
         });
 
         static QUERY_WORD: Lazy<tree_sitter::Query> = Lazy::new(|| {
-            tree_sitter::Query::new(tree_sitter_asm::language(), "(ident) @ident").unwrap()
+            tree_sitter::Query::new(&tree_sitter_asm::language(), "(ident) @ident").unwrap()
         });
 
         let is_not_ident_char = |c: char| !(c.is_alphanumeric() || c == '_');

--- a/src/test.rs
+++ b/src/test.rs
@@ -297,7 +297,7 @@ mod tests {
         let source_code = source.replace("<cursor>", "");
 
         let mut parser = Parser::new();
-        parser.set_language(tree_sitter_asm::language()).unwrap();
+        parser.set_language(&tree_sitter_asm::language()).unwrap();
         let tree = parser.parse(&source_code, None);
         let mut tree_entry = TreeEntry { tree, parser };
 


### PR DESCRIPTION
The basic issue seemed to be that edits weren't properly applied to the tree, allowing for an OOB access in some situations following a deletion in the source file. As far as I can tell, bumping the tree-sitter version fixed the issue reported in #112, so I think this is a bug upstream on tree-sitter's end. If I'm wrong and the issue is still present, I'll get a minimal repo together and file an issue with them.

Closes #112 