### PR TITLE
fix: remove file:// prefix in path comparison inside diagnostics handling code

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -321,7 +321,7 @@ pub fn handle_diagnostics(
     uri: &Uri,
     compile_cmds: &CompilationDatabase,
 ) -> Result<()> {
-    let req_source_path = PathBuf::from(uri.as_str());
+    let req_source_path = PathBuf::from(uri.as_str().replace("file://", ""));
 
     let source_entries = compile_cmds.iter().filter(|entry| match entry.file {
         SourceFile::File(ref file) => {


### PR DESCRIPTION
It looks like I goofed on the path comparison code when comparing between the `uri` in the LSP client's request parameters and the `file` entry for each given compile command. The `file://` prefix in the parameter's `uri` field caused every comparison to evaluate to false. 

cc @RemezovaJulia

Closes #115 