### PR TITLE
feat: add workflow to publish gh binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: asm-lsp
+          target: ${{ matrix.target }}
+          tar: unix
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a first pass on addressing #18 

I followed the [cross-compilation example](https://github.com/marketplace/actions/build-and-upload-rust-binary-to-github-releases#example-workflow-cross-compilation) from the suggested workflow. While everything *looks* reasonable, I'm not sure how to test it without pushing a new release tag.

cc @bergercookie I think it would be nice to be able to use this with coming `0.8.0` release. If you could give this a second look within the next week or two that would be greatly appreciated. Do you know any way we could test this? No pressure if you don't have the bandwidth, though, I can always try it and troubleshoot from there. 😄 

Closes #18 