### PR TITLE
feat: label hover data

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -348,6 +348,7 @@ fn main_loop(
                         id,
                         &params,
                         &text_store,
+                        &mut tree_store,
                         names_to_info,
                         include_dirs,
                     )?;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -36,6 +36,7 @@ pub fn handle_hover_request(
     id: RequestId,
     params: &HoverParams,
     text_store: &TextDocuments,
+    tree_store: &mut TreeStore,
     names_to_info: &NameToInfoMaps,
     include_dirs: &HashMap<SourceFile, Vec<PathBuf>>,
 ) -> Result<()> {
@@ -64,6 +65,8 @@ pub fn handle_hover_request(
         params,
         word,
         file_word,
+        text_store,
+        tree_store,
         &names_to_info.instructions,
         &names_to_info.registers,
         &names_to_info.directives,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,6 +33,10 @@ use url_escape::encode_www_form_urlencoded;
 ///
 /// This function will return `Err` if an xml file within `docs_path` cannot be parsed,
 /// or if `docs_path` cannot be read
+///
+/// # Panics
+///
+/// Will panic the parser fails to extract an instruction name from a given file
 pub fn populate_arm_instructions(docs_path: &PathBuf) -> Result<Vec<Instruction>> {
     let mut instructions_map = HashMap::<String, Instruction>::new();
     let mut alias_map = HashMap::<String, Vec<InstructionAlias>>::new();
@@ -146,7 +150,7 @@ fn parse_arm_alias(xml_contents: &str) -> Result<Option<(InstructionAlias, Strin
                         curr_template = Some(cleaned);
                     }
                 } else if in_desc && in_para && alias.summary.is_empty() {
-                    alias.summary = str::from_utf8(txt)?.to_owned();
+                    str::from_utf8(txt)?.clone_into(&mut alias.summary);
                 }
             }
             Ok(Event::Empty(ref e)) => {
@@ -268,7 +272,7 @@ fn parse_arm_instruction(xml_contents: &str) -> Result<Option<Instruction>> {
                         }
                     }
                 } else if in_desc && in_para && instruction.summary.is_empty() {
-                    instruction.summary = str::from_utf8(txt)?.to_owned();
+                    str::from_utf8(txt)?.clone_into(&mut instruction.summary);
                 }
             }
             // end event --------------------------------------------------------------------------


### PR DESCRIPTION
This adds hover support for labels as requested in #47. When a label is hovered over and it has data directly following it, said data will be shown in a hover window. Implementing this was fairly straightforward, but did require a bit of a refactor in the hover test code. Apologies for taking so long to implement this!

This PR also includes a little cleanup in the parsing code (not sure why clippy didn't catch these warnings in CI).

Quick demo using `samples/gas.s`:

![label_hover](https://github.com/user-attachments/assets/4c0579b7-cb31-45a5-84ad-c73a37399455)

Closes #47 