### PR TITLE
fix: Avoid getting node texts beyond document boundaries

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1259,6 +1259,12 @@ pub fn get_ref_resp(
             let label_matches = cursor.matches(&QUERY_LABEL, tree.root_node(), doc.as_bytes());
             for match_ in label_matches {
                 for cap in match_.captures {
+                    // HACK: Temporary solution for what I believe is a bug in tree-sitter core
+                    if cap.node.start_byte() >= doc.as_bytes().len()
+                        || cap.node.end_byte() >= doc.as_bytes().len()
+                    {
+                        continue;
+                    }
                     let text = cap
                         .node
                         .utf8_text(doc.as_bytes())
@@ -1285,6 +1291,12 @@ pub fn get_ref_resp(
         let word_matches = cursor.matches(&QUERY_WORD, tree.root_node(), doc.as_bytes());
         for match_ in word_matches {
             for cap in match_.captures {
+                // HACK: Temporary solution for what I believe is a bug in tree-sitter core
+                if cap.node.start_byte() >= doc.as_bytes().len()
+                    || cap.node.end_byte() >= doc.as_bytes().len()
+                {
+                    continue;
+                }
                 let text = cap
                     .node
                     .utf8_text(doc.as_bytes())


### PR DESCRIPTION
The basic issue seemed to be that edits weren't properly applied to the tree, allowing for an OOB access in some situations following a deletion in the source file.  I think this is a bug upstream on tree-sitter's end, but I need to investigate further to try and get a minimal repro together to report. For now, we just manually check if a the position for a node's text is beyond the end of our current copy of the document. In such cases, we simply skip a check for that node.

Related #114 #112