### PR TITLE
fix: Add check to root_path field for project path

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -102,6 +102,7 @@ pub fn main() -> Result<()> {
 
     let mut names_to_info = NameToInfoMaps::default();
     let params: InitializeParams = serde_json::from_value(initialization_params.clone()).unwrap();
+    info!("Client initialization params: {:?}", params);
     let target_config = get_target_config(&params);
     info!("Server Configuration: {:?}", target_config);
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1399,6 +1399,8 @@ fn get_global_config() -> Option<TargetConfig> {
 //    the root path
 // 2. If we don't have worksace folders or none of them is a valid path, check the (deprecated)
 //    root_uri field
+// 3. If both workspace folders and root_uri didn't provide a path, check the (deprecated)
+//    root_path field
 fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     // first check workspace folders
     if let Some(folders) = &params.workspace_folders {
@@ -1419,6 +1421,16 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
         if let Ok(parsed) = PathBuf::from_str(root_uri.path().as_str()) {
             if let Ok(parsed_path) = parsed.canonicalize() {
                 info!("Detected project root: {}", parsed_path.display());
+                return Some(parsed_path);
+            }
+        }
+    }
+
+    // if both `workspace_folders` and `root_uri` weren't set or came up empty, we check the root_path
+    #[allow(deprecated)]
+    if let Some(root_path) = &params.root_path {
+        if let Ok(parsed) = PathBuf::from_str(root_path.as_str()) {
+            if let Ok(parsed_path) = parsed.canonicalize() {
                 return Some(parsed_path);
             }
         }


### PR DESCRIPTION
Adds a check for the (deprecated) `root_path` field when trying to determine a project's root directory. Also adds a log statement showing the initialization params received from the client.

Added as part of the investigation for #127 