### PR TITLE
fix(CI): Disable release Windows workflow, patch other release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,22 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
+      # Install dependencies on Linux
+      - name: Install dependencies on Linux
+        if: startsWith(matrix.target, 'x86_64-unknown-linux') || startsWith(matrix.target, 'aarch64-unknown-linux')
+        run: sudo apt-get update && sudo apt-get install -y make
+
+      # Upload Rust binaries
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: asm-lsp
           target: ${{ matrix.target }}
           tar: unix
-          zip: windows
+          # zip: windows
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After some experimenting in a [throwaway repo](https://github.com/WillLillis/asm-lsp-test), I *think* that the non-Windows release actions should be patched. I'm still running into issues with the Windows runner (see #134), so that portion has been commented out for now. The plan is to run another release workflow manually to partially address #134 and #136. I'm planning on fixing the Windows-specific issues when I have some more free time.