### PR TITLE
feat: diagnostics on change, related config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add a section like the following in your `settings.json` file:
 
 Add a `.asm-lsp.toml` file like the following to your project's root directory
 and/or `~/.config/asm-lsp/` (project configs will override global configs). This
-file will cause to selectively target specific assemblers and instruction sets, 
+file will cause to selectively target specific assemblers and instruction sets,
 and/or alter the way it issues diagnostics. Omitting an item from the `assemblers`
 or `instruction_sets` section is equivalent to setting it to `false`.
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Add a section like the following in your `settings.json` file:
 ### [OPTIONAL] Configure via `.asm-lsp.toml`
 
 Add a `.asm-lsp.toml` file like the following to your project's root directory
-and/or `~/.config/asm-lsp/` (project configs will override global configs) to
-selectively target specific assemblers and/or instruction sets. Omitting an item
-from the configuration file is equivalent to setting it to `false`.
+and/or `~/.config/asm-lsp/` (project configs will override global configs). This
+file will cause to selectively target specific assemblers and instruction sets, 
+and/or alter the way it issues diagnostics. Omitting an item from the `assemblers`
+or `instruction_sets` section is equivalent to setting it to `false`.
 
 ```toml
 version = "0.1"
@@ -62,6 +63,10 @@ x86_64 = true
 z80 = false
 arm = false
 riscv = false
+
+[opts]
+diagnostic_trigger = "OnSave" # Off, OnRequest, OnSave, OnChange
+diagnostic_debounce = 500
 ```
 
 ### [OPTIONAL] Extend functionality via `compile_commands.json`/`compile_flags.txt`

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -18,8 +18,8 @@ use tree_sitter::Parser;
 
 use crate::{
     apply_compile_cmd, get_comp_resp, get_document_symbols, get_goto_def_resp, get_hover_resp,
-    get_ref_resp, get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit,
-    NameToInfoMaps, NameToInstructionMap, TargetConfig, TreeEntry, TreeStore,
+    get_ref_resp, get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit, Config,
+    NameToInfoMaps, NameToInstructionMap, TreeEntry, TreeStore,
 };
 
 /// Handles hover requests
@@ -35,7 +35,7 @@ use crate::{
 pub fn handle_hover_request(
     connection: &Connection,
     id: RequestId,
-    config: &TargetConfig,
+    config: &Config,
     params: &HoverParams,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
@@ -95,7 +95,7 @@ pub fn handle_completion_request(
     connection: &Connection,
     id: RequestId,
     params: &CompletionParams,
-    config: &TargetConfig,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
     instruction_completion_items: &[CompletionItem],

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,12 +19,12 @@ mod tests {
         parser::{get_cache_dir, populate_arm_instructions, populate_masm_nasm_directives},
         populate_gas_directives, populate_instructions, populate_name_to_directive_map,
         populate_name_to_instruction_map, populate_name_to_register_map, populate_registers, Arch,
-        Assembler, Assemblers, Directive, Instruction, InstructionSets, NameToDirectiveMap,
-        NameToInstructionMap, NameToRegisterMap, Register, TargetConfig, TreeEntry, TreeStore,
+        Assembler, Assemblers, Config, Directive, Instruction, InstructionSets, NameToDirectiveMap,
+        NameToInstructionMap, NameToRegisterMap, Options, Register, TreeEntry, TreeStore,
     };
 
-    fn empty_test_config() -> TargetConfig {
-        TargetConfig {
+    fn empty_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -40,11 +40,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn z80_test_config() -> TargetConfig {
-        TargetConfig {
+    fn z80_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -60,11 +61,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn arm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn arm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -80,11 +82,12 @@ mod tests {
                 arm: Some(true),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn riscv_test_config() -> TargetConfig {
-        TargetConfig {
+    fn riscv_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -100,11 +103,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(true),
             },
+            opts: Options::default(),
         }
     }
 
-    fn x86_x86_64_test_config() -> TargetConfig {
-        TargetConfig {
+    fn x86_x86_64_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(true),
@@ -120,11 +124,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn gas_test_config() -> TargetConfig {
-        TargetConfig {
+    fn gas_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(true),
@@ -140,11 +145,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn masm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn masm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -160,11 +166,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
-    fn nasm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn nasm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -180,6 +187,7 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: Options::default(),
         }
     }
 
@@ -243,7 +251,7 @@ mod tests {
         }
     }
 
-    fn init_global_info(config: &TargetConfig) -> Result<GlobalInfo> {
+    fn init_global_info(config: &Config) -> Result<GlobalInfo> {
         let mut info = GlobalInfo::new();
 
         info.x86_instructions = if config.instruction_sets.x86.unwrap_or(false) {
@@ -466,7 +474,7 @@ mod tests {
         return Ok(store);
     }
 
-    fn test_hover(source: &str, expected: &str, config: &TargetConfig) {
+    fn test_hover(source: &str, expected: &str, config: &Config) {
         let info = init_global_info(config).expect("Failed to load info");
         let globals = init_test_store(&info).expect("Failed to initialize test store");
 
@@ -555,7 +563,7 @@ mod tests {
 
     fn test_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         expected_kind: CompletionItemKind,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
@@ -633,7 +641,7 @@ mod tests {
 
     fn test_register_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {
@@ -649,7 +657,7 @@ mod tests {
 
     fn test_instruction_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {
@@ -665,7 +673,7 @@ mod tests {
 
     fn test_directive_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -851,19 +851,38 @@ impl Default for InstructionSets {
     }
 }
 
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiagnosticTrigger {
+    Off,
+    OnRequest,
+    #[default]
+    OnSave,
+    OnChange,
+}
+
+pub const DIAGNOSTIC_DEBOUNCE_MS: u64 = 500;
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Options {
+    pub diagnostic_trigger: Option<DiagnosticTrigger>,
+    pub diagnostic_debounce: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TargetConfig {
+pub struct Config {
     pub version: String,
     pub assemblers: Assemblers,
     pub instruction_sets: InstructionSets,
+    pub opts: Options,
 }
 
-impl Default for TargetConfig {
+impl Default for Config {
     fn default() -> Self {
-        TargetConfig {
+        Config {
             version: String::from("0.1"),
             assemblers: Assemblers::default(),
             instruction_sets: InstructionSets::default(),
+            opts: Options::default(),
         }
     }
 }


### PR DESCRIPTION
This is a first pass on addressing some of the diagnostics issues mentioned in #138. Specifically, this PR adds the option to enable diagnostics whenever a `DidChangeTextDocument` notification is service. A new `opts` section has been added to `.asm-lsp.toml`, which currently has two (optional) fields:

- `diagnostic_trigger`: Takes on the values `Off`, `OnRequest`, `OnSave` (the default), or `OnChange`.

  - Selecting a value also enables all of the values "below" it. For example, selecting the `OnSave` option will enable diagnostics on save and on request.
- `diagnostic_debounce`: Defaults to a value of 500ms. This adds debouncing in the case where the above value is `OnChange`.

EDIT: This will require a little more thought. Since we gather diagnostics by invoking a compiler/assembler on the system, any unwritten changes made to the file won't be seen by the compiler/assembler, and thus won't appear in the server's diagnostics. We *could* hack around this by writing our in-memory copy to disk first, but this seems rather hacky and could be error prone.

cc @patrick6razno Perfectly happy to iterate on this further if you have any suggestions/ feedback. :)