### PR TITLE
fix(ci): Restore Windows release workflow

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -53,6 +53,40 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo ln -s "$(which ruby)" /usr/bin/ruby3.2
 
+      # Install Strawberry Perl
+      - name: Install Strawberry Perl
+        if: runner.os == 'Windows'
+        run: choco install strawberryperl --version=5.32.1.1
+
+      # Set Perl environment to Strawberry Perl
+      - name: Set Perl environment to Strawberry Perl
+        if: runner.os == 'Windows'
+        run: echo "PERL=C:/Strawberry/perl/bin/perl.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      # Install MSYS2 and MinGW on Windows
+      - name: Install MSYS2 and MinGW on Windows
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-openssl
+            base-devel
+          path-type: inherit
+
+      - name: Set MinGW environment for OpenSSL build
+        if: runner.os == 'Windows'
+        run: |
+          echo "C:/msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          echo "CC=/mingw64/bin/gcc" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CXX=/mingw64/bin/g++" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install OpenSSL via vcpkg
+        if: runner.os == 'Windows'
+        run: vcpkg install openssl:x64-windows-static-md
+
       - name: Install pre-commit dependencies
         run: python -m pip install pre-commit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -41,11 +41,23 @@ jobs:
         if: startsWith(matrix.target, 'x86_64-unknown-linux') || startsWith(matrix.target, 'aarch64-unknown-linux')
         run: sudo apt-get update && sudo apt-get install -y make openssl libssl-dev
 
+      # Windows
+      # TODO: Fix this via testing in lint_and_test.yml, then copy over here
+      # - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+      #   if: runner.os == 'Windows'
+      # - run: vcpkg install openssl:x64-windows-static-md
+      #   if: runner.os == 'Windows'
+      # - name: Set Perl environment variables
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+      #     echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       # Upload Rust binaries
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: asm-lsp
           target: ${{ matrix.target }}
           tar: unix
-          # zip: windows
+          zip: windows
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the windows release runner. During testing, I also found that the [symbolic-demangle crate](https://github.com/getsentry/symbolic) fails to build on aarch64-linux, so I've disabled that run for now.

EDIT: It looks like vendoring some of our dependencies broke the lint and test runners on Windows. Planning on picking this work back up again soon.