### PR TITLE
fix: proper usage of compile_flags.txt for diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,8 +244,7 @@ dependencies = [
 [[package]]
 name = "compile_commands"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d05c707e1d0f610edfb30523e2d654d1779b58db656191630026ddaca2a6dd3"
+source = "git+https://github.com/WillLillis/compile_commands?rev=ccf28aef46207c810c0c1f2e264f92c66c0d2000#ccf28aef46207c810c0c1f2e264f92c66c0d2000"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,8 @@ url-escape = "0.1.1"
 quick-xml = "0.35.0"
 bincode = "1.3.3"
 lsp-textdocument = "0.4.0"
-compile_commands = "0.2.0"
+# compile_commands = "0.2.0"
+compile_commands = { git = "https://github.com/WillLillis/compile_commands", rev = "ccf28aef46207c810c0c1f2e264f92c66c0d2000" }
 tree-sitter = "0.22.6"
 tree-sitter-asm = "0.22.6"
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Add a section like the following in your `settings.json` file:
 Add a `.asm-lsp.toml` file like the following to your project's root directory
 and/or `~/.config/asm-lsp/` (project configs will override global configs) to
 selectively target specific assemblers and/or instruction sets. Omitting an item
-from the configuration file is equivalent to setting it to `false`.
+from the `assemblers` or `instruction_sets` sections is equivalent to setting it
+to `false`. Be default, the server attempts to invoke `gcc` (and then `clang`)
+to generate diagnostics. If `compiler` config field is specified, the server will
+attempt to use the specified path to generate diagnostics.
 
 ```toml
 version = "0.1"
@@ -62,14 +65,18 @@ x86_64 = true
 z80 = false
 arm = false
 riscv = false
+
+[opts]
+#compiler = "gcc"
 ```
 
 ### [OPTIONAL] Extend functionality via `compile_commands.json`/`compile_flags.txt`
 
 Add a [`compile_commands.json`](https://clang.llvm.org/docs/JSONCompilationDatabase.html#format)
 or [`compile_flags.txt`](https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives)
-file to your project's `build` directory to enable inline diagnostic features, as
-well as to specify additional include directories for use in hover features.
+file to your project's root or root `build` directory to enable inline diagnostic
+features, as well as to specify additional include directories for use in hover
+features.
 
 ### VSCode Support
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Add a `.asm-lsp.toml` file like the following to your project's root directory
 and/or `~/.config/asm-lsp/` (project configs will override global configs) to
 selectively target specific assemblers and/or instruction sets. Omitting an item
 from the `assemblers` or `instruction_sets` sections is equivalent to setting it
-to `false`. Be default, the server attempts to invoke `gcc` (and then `clang`)
-to generate diagnostics. If `compiler` config field is specified, the server will
-attempt to use the specified path to generate diagnostics.
+to `false`. Be default, diagnostics are enabled and the server attempts to invoke
+`gcc` (and then `clang`) to generate them. If the `compiler` config field is specified,
+the server will attempt to use the specified path to generate diagnostics.
 
 ```toml
 version = "0.1"
@@ -68,6 +68,8 @@ riscv = false
 
 [opts]
 #compiler = "gcc"
+diagnostics = true
+default_diagnostics = true
 ```
 
 ### [OPTIONAL] Extend functionality via `compile_commands.json`/`compile_flags.txt`
@@ -76,7 +78,10 @@ Add a [`compile_commands.json`](https://clang.llvm.org/docs/JSONCompilationDatab
 or [`compile_flags.txt`](https://clang.llvm.org/docs/JSONCompilationDatabase.html#alternatives)
 file to your project's root or root `build` directory to enable inline diagnostic
 features, as well as to specify additional include directories for use in hover
-features.
+features. If a `compile_commands.json` or `compile_flags.txt` file isn't provided,
+the server will attempt to provide diagnostics with a default compile command.
+This feature can be disabled by setting the `default_diagnostics` config field
+to `false`.
 
 ### VSCode Support
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -10,8 +10,7 @@ use asm_lsp::handle::{
 use asm_lsp::{
     get_compile_cmds, get_completes, get_include_dirs, get_target_config, instr_filter_targets,
     populate_name_to_directive_map, populate_name_to_instruction_map,
-    populate_name_to_register_map, Arch, Assembler, Instruction, NameToInfoMaps, TargetConfig,
-    TreeStore,
+    populate_name_to_register_map, Arch, Assembler, Config, Instruction, NameToInfoMaps, TreeStore,
 };
 
 use compile_commands::{CompilationDatabase, SourceFile};
@@ -397,7 +396,7 @@ pub fn main() -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 fn main_loop(
     connection: &Connection,
-    config: &TargetConfig,
+    config: &Config,
     names_to_info: &NameToInfoMaps,
     instruction_completion_items: &[CompletionItem],
     directive_completion_items: &[CompletionItem],
@@ -492,7 +491,12 @@ fn main_loop(
                     );
                 } else if let Ok((_id, params)) = cast_req::<DocumentDiagnosticRequest>(req.clone())
                 {
-                    handle_diagnostics(connection, &params.text_document.uri, compile_cmds)?;
+                    handle_diagnostics(
+                        connection,
+                        &params.text_document.uri,
+                        config,
+                        compile_cmds,
+                    )?;
                     info!(
                         "Diagnostics request serviced in {}ms",
                         start.elapsed().as_millis()
@@ -533,7 +537,12 @@ fn main_loop(
                         start.elapsed().as_millis()
                     );
                 } else if let Ok(params) = cast_notif::<DidSaveTextDocument>(notif.clone()) {
-                    handle_diagnostics(connection, &params.text_document.uri, compile_cmds)?;
+                    handle_diagnostics(
+                        connection,
+                        &params.text_document.uri,
+                        config,
+                        compile_cmds,
+                    )?;
                     info!(
                         "Published diagnostics on save in {}ms",
                         start.elapsed().as_millis()

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -8,7 +8,7 @@ use asm_lsp::handle::{
     handle_references_request, handle_signature_help_request,
 };
 use asm_lsp::{
-    get_compile_cmds, get_completes, get_include_dirs, get_target_config, instr_filter_targets,
+    get_compile_cmds, get_completes, get_config, get_include_dirs, instr_filter_targets,
     populate_name_to_directive_map, populate_name_to_instruction_map,
     populate_name_to_register_map, Arch, Assembler, Config, Instruction, NameToInfoMaps, TreeStore,
 };
@@ -103,20 +103,20 @@ pub fn main() -> Result<()> {
     let mut names_to_info = NameToInfoMaps::default();
     let params: InitializeParams = serde_json::from_value(initialization_params.clone()).unwrap();
     info!("Client initialization params: {:?}", params);
-    let target_config = get_target_config(&params);
-    info!("Server Configuration: {:?}", target_config);
+    let config = get_config(&params);
+    info!("Server Configuration: {:?}", config);
 
     // create a map of &Instruction_name -> &Instruction - Use that in user queries
     // The Instruction(s) themselves are stored in a vector and we only keep references to the
     // former map
-    let x86_instructions = if target_config.instruction_sets.x86.unwrap_or(false) {
+    let x86_instructions = if config.instruction_sets.x86.unwrap_or(false) {
         let start = std::time::Instant::now();
         let x86_instrs = include_bytes!("../../docs_store/opcodes/serialized/x86");
         let instrs = bincode::deserialize::<Vec<Instruction>>(x86_instrs)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
-                instr_filter_targets(&instruction, &target_config)
+                instr_filter_targets(&instruction, &config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
             .collect();
@@ -129,14 +129,14 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let x86_64_instructions = if target_config.instruction_sets.x86_64.unwrap_or(false) {
+    let x86_64_instructions = if config.instruction_sets.x86_64.unwrap_or(false) {
         let start = std::time::Instant::now();
         let x86_64_instrs = include_bytes!("../../docs_store/opcodes/serialized/x86_64");
         let instrs = bincode::deserialize::<Vec<Instruction>>(x86_64_instrs)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
-                instr_filter_targets(&instruction, &target_config)
+                instr_filter_targets(&instruction, &config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
             .collect();
@@ -149,14 +149,14 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let z80_instructions = if target_config.instruction_sets.z80.unwrap_or(false) {
+    let z80_instructions = if config.instruction_sets.z80.unwrap_or(false) {
         let start = std::time::Instant::now();
         let z80_instrs = include_bytes!("../../docs_store/opcodes/serialized/z80");
         let instrs = bincode::deserialize::<Vec<Instruction>>(z80_instrs)?
             .into_iter()
             .map(|instruction| {
                 // filter out assemblers by user config
-                instr_filter_targets(&instruction, &target_config)
+                instr_filter_targets(&instruction, &config)
             })
             .filter(|instruction| !instruction.forms.is_empty())
             .collect();
@@ -169,7 +169,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let arm_instructions = if target_config.instruction_sets.arm.unwrap_or(false) {
+    let arm_instructions = if config.instruction_sets.arm.unwrap_or(false) {
         let start = std::time::Instant::now();
         let arm_instrs = include_bytes!("../../docs_store/opcodes/serialized/arm");
         // NOTE: No need to filter these instructions by assembler like we do for
@@ -184,7 +184,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let riscv_instructions = if target_config.instruction_sets.riscv.unwrap_or(false) {
+    let riscv_instructions = if config.instruction_sets.riscv.unwrap_or(false) {
         let start = std::time::Instant::now();
         let riscv_instrs = include_bytes!("../../docs_store/opcodes/serialized/riscv");
         // NOTE: No need to filter these instructions by assembler like we do for
@@ -228,7 +228,7 @@ pub fn main() -> Result<()> {
     // create a map of &Register_name -> &Register - Use that in user queries
     // The Register(s) themselves are stored in a vector and we only keep references to the
     // former map
-    let x86_registers = if target_config.instruction_sets.x86.unwrap_or(false) {
+    let x86_registers = if config.instruction_sets.x86.unwrap_or(false) {
         let start = std::time::Instant::now();
         let regs_x86 = include_bytes!("../../docs_store/registers/serialized/x86");
         let regs = bincode::deserialize(regs_x86)?;
@@ -241,7 +241,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let x86_64_registers = if target_config.instruction_sets.x86_64.unwrap_or(false) {
+    let x86_64_registers = if config.instruction_sets.x86_64.unwrap_or(false) {
         let start = std::time::Instant::now();
         let regs_x86_64 = include_bytes!("../../docs_store/registers/serialized/x86_64");
         let regs = bincode::deserialize(regs_x86_64)?;
@@ -254,7 +254,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let z80_registers = if target_config.instruction_sets.z80.unwrap_or(false) {
+    let z80_registers = if config.instruction_sets.z80.unwrap_or(false) {
         let start = std::time::Instant::now();
         let regs_z80 = include_bytes!("../../docs_store/registers/serialized/z80");
         let regs = bincode::deserialize(regs_z80)?;
@@ -267,7 +267,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let arm_registers = if target_config.instruction_sets.arm.unwrap_or(false) {
+    let arm_registers = if config.instruction_sets.arm.unwrap_or(false) {
         let start = std::time::Instant::now();
         let regs_arm = include_bytes!("../../docs_store/registers/serialized/arm");
         let regs = bincode::deserialize(regs_arm)?;
@@ -280,7 +280,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let riscv_registers = if target_config.instruction_sets.riscv.unwrap_or(false) {
+    let riscv_registers = if config.instruction_sets.riscv.unwrap_or(false) {
         let start = std::time::Instant::now();
         let regs_riscv = include_bytes!("../../docs_store/registers/serialized/riscv");
         let regs = bincode::deserialize(regs_riscv)?;
@@ -303,7 +303,7 @@ pub fn main() -> Result<()> {
     populate_name_to_register_map(Arch::ARM, &arm_registers, &mut names_to_info.registers);
     populate_name_to_register_map(Arch::RISCV, &riscv_registers, &mut names_to_info.registers);
 
-    let gas_directives = if target_config.assemblers.gas.unwrap_or(false) {
+    let gas_directives = if config.assemblers.gas.unwrap_or(false) {
         let start = std::time::Instant::now();
         let gas_dirs = include_bytes!("../../docs_store/directives/serialized/gas");
         let dirs = bincode::deserialize(gas_dirs)?;
@@ -316,7 +316,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let masm_directives = if target_config.assemblers.masm.unwrap_or(false) {
+    let masm_directives = if config.assemblers.masm.unwrap_or(false) {
         let start = std::time::Instant::now();
         let masm_dirs = include_bytes!("../../docs_store/directives/serialized/masm");
         let dirs = bincode::deserialize(masm_dirs)?;
@@ -329,7 +329,7 @@ pub fn main() -> Result<()> {
         Vec::new()
     };
 
-    let nasm_directives = if target_config.assemblers.nasm.unwrap_or(false) {
+    let nasm_directives = if config.assemblers.nasm.unwrap_or(false) {
         let start = std::time::Instant::now();
         let nasm_dirs = include_bytes!("../../docs_store/directives/serialized/nasm");
         let dirs = bincode::deserialize(nasm_dirs)?;
@@ -375,7 +375,7 @@ pub fn main() -> Result<()> {
 
     main_loop(
         &connection,
-        &target_config,
+        &config,
         &names_to_info,
         &instr_completion_items,
         &directive_completion_items,
@@ -491,16 +491,19 @@ fn main_loop(
                     );
                 } else if let Ok((_id, params)) = cast_req::<DocumentDiagnosticRequest>(req.clone())
                 {
-                    handle_diagnostics(
-                        connection,
-                        &params.text_document.uri,
-                        config,
-                        compile_cmds,
-                    )?;
-                    info!(
-                        "Diagnostics request serviced in {}ms",
-                        start.elapsed().as_millis()
-                    );
+                    // Ok to unwrap, this should never be `None`
+                    if config.opts.diagnostics.unwrap() {
+                        handle_diagnostics(
+                            connection,
+                            &params.text_document.uri,
+                            config,
+                            compile_cmds,
+                        )?;
+                        info!(
+                            "Diagnostics request serviced in {}ms",
+                            start.elapsed().as_millis()
+                        );
+                    }
                 } else {
                     error!("Invalid request format -> {:#?}", req);
                 }
@@ -537,16 +540,19 @@ fn main_loop(
                         start.elapsed().as_millis()
                     );
                 } else if let Ok(params) = cast_notif::<DidSaveTextDocument>(notif.clone()) {
-                    handle_diagnostics(
-                        connection,
-                        &params.text_document.uri,
-                        config,
-                        compile_cmds,
-                    )?;
-                    info!(
-                        "Published diagnostics on save in {}ms",
-                        start.elapsed().as_millis()
-                    );
+                    // Ok to unwrap, this should never be `None`
+                    if config.opts.diagnostics.unwrap() {
+                        handle_diagnostics(
+                            connection,
+                            &params.text_document.uri,
+                            config,
+                            compile_cmds,
+                        )?;
+                        info!(
+                            "Published diagnostics on save in {}ms",
+                            start.elapsed().as_millis()
+                        );
+                    }
                 }
             }
             Message::Response(_resp) => {}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 use compile_commands::{CompilationDatabase, SourceFile};
+use log::info;
 use lsp_server::{Connection, Message, RequestId, Response};
 use lsp_textdocument::TextDocuments;
 use lsp_types::{
@@ -17,9 +18,9 @@ use lsp_types::{
 use tree_sitter::Parser;
 
 use crate::{
-    apply_compile_cmd, get_comp_resp, get_document_symbols, get_goto_def_resp, get_hover_resp,
-    get_ref_resp, get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit, Config,
-    NameToInfoMaps, NameToInstructionMap, TreeEntry, TreeStore,
+    apply_compile_cmd, get_comp_resp, get_default_compile_cmd, get_document_symbols,
+    get_goto_def_resp, get_hover_resp, get_ref_resp, get_sig_help_resp, get_word_from_pos_params,
+    text_doc_change_to_ts_edit, Config, NameToInfoMaps, NameToInstructionMap, TreeEntry, TreeStore,
 };
 
 /// Handles hover requests
@@ -339,9 +340,22 @@ pub fn handle_diagnostics(
         SourceFile::All => true,
     });
 
+    let mut has_entries = false;
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for entry in source_entries {
+        has_entries = true;
         apply_compile_cmd(cfg, &mut diagnostics, entry);
+    }
+
+    // If no user-provided entries corresponded to the file, just try out
+    // invoking the user-provided compiler (if they gave one), or alternatively
+    // gcc (and clang if that fails) with the source file path as the only argument
+    if !has_entries {
+        info!(
+            "No applicable user-provided commands for {}. Applying default compile command",
+            uri.path().as_str()
+        );
+        apply_compile_cmd(cfg, &mut diagnostics, &get_default_compile_cmd(uri, cfg));
     }
 
     let params = PublishDiagnosticsParams {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -18,8 +18,8 @@ use tree_sitter::Parser;
 
 use crate::{
     apply_compile_cmd, get_comp_resp, get_document_symbols, get_goto_def_resp, get_hover_resp,
-    get_ref_resp, get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit,
-    NameToInfoMaps, NameToInstructionMap, TargetConfig, TreeEntry, TreeStore,
+    get_ref_resp, get_sig_help_resp, get_word_from_pos_params, text_doc_change_to_ts_edit, Config,
+    NameToInfoMaps, NameToInstructionMap, TreeEntry, TreeStore,
 };
 
 /// Handles hover requests
@@ -35,7 +35,7 @@ use crate::{
 pub fn handle_hover_request(
     connection: &Connection,
     id: RequestId,
-    config: &TargetConfig,
+    config: &Config,
     params: &HoverParams,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
@@ -95,7 +95,7 @@ pub fn handle_completion_request(
     connection: &Connection,
     id: RequestId,
     params: &CompletionParams,
-    config: &TargetConfig,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
     instruction_completion_items: &[CompletionItem],
@@ -321,6 +321,7 @@ pub fn handle_references_request(
 pub fn handle_diagnostics(
     connection: &Connection,
     uri: &Uri,
+    cfg: &Config,
     compile_cmds: &CompilationDatabase,
 ) -> Result<()> {
     let req_source_path = PathBuf::from(uri.path().as_str());
@@ -340,7 +341,7 @@ pub fn handle_diagnostics(
 
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for entry in source_entries {
-        apply_compile_cmd(&mut diagnostics, entry);
+        apply_compile_cmd(cfg, &mut diagnostics, entry);
     }
 
     let params = PublishDiagnosticsParams {

--- a/src/test.rs
+++ b/src/test.rs
@@ -41,7 +41,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -62,7 +66,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -83,7 +91,11 @@ mod tests {
                 arm: Some(true),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -104,7 +116,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(true),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -125,7 +141,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -146,7 +166,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -167,7 +191,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 
@@ -188,7 +216,11 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
-            opts: ConfigOptions { compiler: None },
+            opts: ConfigOptions {
+                compiler: None,
+                diagnostics: None,
+                default_diagnostics: None,
+            },
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,12 +19,13 @@ mod tests {
         parser::{get_cache_dir, populate_arm_instructions, populate_masm_nasm_directives},
         populate_gas_directives, populate_instructions, populate_name_to_directive_map,
         populate_name_to_instruction_map, populate_name_to_register_map, populate_registers, Arch,
-        Assembler, Assemblers, Directive, Instruction, InstructionSets, NameToDirectiveMap,
-        NameToInstructionMap, NameToRegisterMap, Register, TargetConfig, TreeEntry, TreeStore,
+        Assembler, Assemblers, Config, ConfigOptions, Directive, Instruction, InstructionSets,
+        NameToDirectiveMap, NameToInstructionMap, NameToRegisterMap, Register, TreeEntry,
+        TreeStore,
     };
 
-    fn empty_test_config() -> TargetConfig {
-        TargetConfig {
+    fn empty_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -40,11 +41,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn z80_test_config() -> TargetConfig {
-        TargetConfig {
+    fn z80_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -60,11 +62,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn arm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn arm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -80,11 +83,12 @@ mod tests {
                 arm: Some(true),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn riscv_test_config() -> TargetConfig {
-        TargetConfig {
+    fn riscv_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -100,11 +104,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(true),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn x86_x86_64_test_config() -> TargetConfig {
-        TargetConfig {
+    fn x86_x86_64_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(true),
@@ -120,11 +125,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn gas_test_config() -> TargetConfig {
-        TargetConfig {
+    fn gas_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(true),
@@ -140,11 +146,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn masm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn masm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -160,11 +167,12 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
-    fn nasm_test_config() -> TargetConfig {
-        TargetConfig {
+    fn nasm_test_config() -> Config {
+        Config {
             version: "0.1".to_string(),
             assemblers: Assemblers {
                 gas: Some(false),
@@ -180,6 +188,7 @@ mod tests {
                 arm: Some(false),
                 riscv: Some(false),
             },
+            opts: ConfigOptions { compiler: None },
         }
     }
 
@@ -243,7 +252,7 @@ mod tests {
         }
     }
 
-    fn init_global_info(config: &TargetConfig) -> Result<GlobalInfo> {
+    fn init_global_info(config: &Config) -> Result<GlobalInfo> {
         let mut info = GlobalInfo::new();
 
         info.x86_instructions = if config.instruction_sets.x86.unwrap_or(false) {
@@ -466,7 +475,7 @@ mod tests {
         return Ok(store);
     }
 
-    fn test_hover(source: &str, expected: &str, config: &TargetConfig) {
+    fn test_hover(source: &str, expected: &str, config: &Config) {
         let info = init_global_info(config).expect("Failed to load info");
         let globals = init_test_store(&info).expect("Failed to initialize test store");
 
@@ -555,7 +564,7 @@ mod tests {
 
     fn test_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         expected_kind: CompletionItemKind,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
@@ -633,7 +642,7 @@ mod tests {
 
     fn test_register_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {
@@ -649,7 +658,7 @@ mod tests {
 
     fn test_instruction_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {
@@ -665,7 +674,7 @@ mod tests {
 
     fn test_directive_autocomplete(
         source: &str,
-        config: &TargetConfig,
+        config: &Config,
         trigger_kind: CompletionTriggerKind,
         trigger_character: Option<String>,
     ) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -851,9 +851,21 @@ impl Default for InstructionSets {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigOptions {
     pub compiler: Option<String>,
+    pub diagnostics: Option<bool>,
+    pub default_diagnostics: Option<bool>,
+}
+
+impl Default for ConfigOptions {
+    fn default() -> Self {
+        Self {
+            compiler: None,
+            diagnostics: Some(true),
+            default_diagnostics: Some(true),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -851,19 +851,26 @@ impl Default for InstructionSets {
     }
 }
 
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigOptions {
+    pub compiler: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TargetConfig {
+pub struct Config {
     pub version: String,
     pub assemblers: Assemblers,
     pub instruction_sets: InstructionSets,
+    pub opts: ConfigOptions,
 }
 
-impl Default for TargetConfig {
+impl Default for Config {
     fn default() -> Self {
-        TargetConfig {
+        Config {
             version: String::from("0.1"),
             assemblers: Assemblers::default(),
             instruction_sets: InstructionSets::default(),
+            opts: ConfigOptions::default(),
         }
     }
 }


### PR DESCRIPTION
This corrects the treatment of `compile_flags.txt` during the server's generation of diagnostics. The server now treats `compile_flags.txt` files correctly, as if they only contain flags. If such a file is loaded, the server will attempt to invoke `gcc` with the provided flags. If it fails to invoke `gcc`, it will also try `clang`. There is a new `opts` section of `.asm-lsp.toml` with an optional `compiler` entry. If the `compiler` field is set, the server will attempt to invoke the provided compiler in order to generate diagnostics. 

This also enables diagnostics by *default*. That is, if no compile command applies to the source file when a request comes in, the server will still try to invoke `gcc` (and if that fails, `clang`) on the contents of the current buffer, with the file path being the only argument. This enables diagnostics even when no `compile_commands.json` or `compile_flags.txt` are available for the current project.

Closes #138 