### PR TITLE
fix: Issues with `compile_flags.txt`

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -355,7 +355,12 @@ pub fn handle_diagnostics(
             "No applicable user-provided commands for {}. Applying default compile command",
             uri.path().as_str()
         );
-        apply_compile_cmd(cfg, &mut diagnostics, uri, &get_default_compile_cmd(uri, cfg));
+        apply_compile_cmd(
+            cfg,
+            &mut diagnostics,
+            uri,
+            &get_default_compile_cmd(uri, cfg),
+        );
     }
 
     let params = PublishDiagnosticsParams {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -344,7 +344,7 @@ pub fn handle_diagnostics(
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for entry in source_entries {
         has_entries = true;
-        apply_compile_cmd(cfg, &mut diagnostics, entry);
+        apply_compile_cmd(cfg, &mut diagnostics, uri, entry);
     }
 
     // If no user-provided entries corresponded to the file, just try out
@@ -355,7 +355,7 @@ pub fn handle_diagnostics(
             "No applicable user-provided commands for {}. Applying default compile command",
             uri.path().as_str()
         );
-        apply_compile_cmd(cfg, &mut diagnostics, &get_default_compile_cmd(uri, cfg));
+        apply_compile_cmd(cfg, &mut diagnostics, uri, &get_default_compile_cmd(uri, cfg));
     }
 
     let params = PublishDiagnosticsParams {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -366,10 +366,6 @@ pub fn apply_compile_cmd(
     if let Some(ref args) = compile_cmd.arguments {
         match args {
             CompileArgs::Flags(flags) => {
-                if flags.is_empty() {
-                    return;
-                }
-
                 let compilers = if let Some(ref compiler) = cfg.opts.compiler {
                     // If the user specified a compiler in their config, use it
                     vec![compiler.as_str()]


### PR DESCRIPTION
#148 pointed out a few issues with the server's current generation of diagnostics. 

First, error messages with both line and column information (I originally tested this feature with gcc, which only outputs line information) causes the regex to misbehave, reporting the column number as the line number. This was solved by introducing a second regex that looks for both numbers. If that fails to match properly, the original regex is used instead. 

Second, the source file *clearly* needs to be passed along as an argument to compiler when using `compile_flags.txt`. 

Lastly, I removed an early return which allows the server to still produce diagnostics when an empty `compile_flags.txt` file is used.


Partially addresses #148