### PR TITLE
fix: Don't send empty response to Helix client

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -20,7 +20,8 @@ use tree_sitter::Parser;
 use crate::{
     apply_compile_cmd, get_comp_resp, get_default_compile_cmd, get_document_symbols,
     get_goto_def_resp, get_hover_resp, get_ref_resp, get_sig_help_resp, get_word_from_pos_params,
-    text_doc_change_to_ts_edit, Config, NameToInfoMaps, NameToInstructionMap, TreeEntry, TreeStore,
+    send_empty_resp, text_doc_change_to_ts_edit, Config, NameToInfoMaps, NameToInstructionMap,
+    TreeEntry, TreeStore,
 };
 
 /// Handles hover requests
@@ -43,20 +44,12 @@ pub fn handle_hover_request(
     names_to_info: &NameToInfoMaps,
     include_dirs: &HashMap<SourceFile, Vec<PathBuf>>,
 ) -> Result<()> {
-    let empty_resp = Response {
-        id: id.clone(),
-        result: None,
-        error: None,
-    };
-
     let word = if let Some(doc) =
         text_store.get_document(&params.text_document_position_params.text_document.uri)
     {
         get_word_from_pos_params(doc, &params.text_document_position_params)
     } else {
-        return Ok(connection
-            .sender
-            .send(Message::Response(empty_resp.clone()))?);
+        return send_empty_resp(connection, id, config);
     };
 
     if let Some(hover_resp) = get_hover_resp(
@@ -79,7 +72,7 @@ pub fn handle_hover_request(
         return Ok(connection.sender.send(Message::Response(result))?);
     }
 
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Handles completion requests
@@ -126,13 +119,7 @@ pub fn handle_completion_request(
         }
     }
 
-    let empty_resp = Response {
-        id,
-        result: None,
-        error: None,
-    };
-
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Handles go to definition requests
@@ -148,6 +135,7 @@ pub fn handle_goto_def_request(
     connection: &Connection,
     id: RequestId,
     params: &GotoDefinitionParams,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
 ) -> Result<()> {
@@ -167,13 +155,7 @@ pub fn handle_goto_def_request(
         }
     }
 
-    let empty_resp = Response {
-        id,
-        result: None,
-        error: None,
-    };
-
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Handles document symbols requests
@@ -189,6 +171,7 @@ pub fn handle_document_symbols_request(
     connection: &Connection,
     id: RequestId,
     params: &DocumentSymbolParams,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
 ) -> Result<()> {
@@ -208,13 +191,7 @@ pub fn handle_document_symbols_request(
         }
     }
 
-    let empty_resp = Response {
-        id,
-        result: None,
-        error: None,
-    };
-
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Handles signature help requests
@@ -230,6 +207,7 @@ pub fn handle_signature_help_request(
     connection: &Connection,
     id: RequestId,
     params: &SignatureHelpParams,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
     names_to_instructions: &NameToInstructionMap,
@@ -257,13 +235,7 @@ pub fn handle_signature_help_request(
         }
     }
 
-    let empty_resp = Response {
-        id,
-        result: None,
-        error: None,
-    };
-
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Handles reference requests
@@ -279,6 +251,7 @@ pub fn handle_references_request(
     connection: &Connection,
     id: RequestId,
     params: &ReferenceParams,
+    config: &Config,
     text_store: &TextDocuments,
     tree_store: &mut TreeStore,
 ) -> Result<()> {
@@ -299,13 +272,7 @@ pub fn handle_references_request(
         }
     }
 
-    let empty_resp = Response {
-        id,
-        result: None,
-        error: None,
-    };
-
-    Ok(connection.sender.send(Message::Response(empty_resp))?)
+    send_empty_resp(connection, id, config)
 }
 
 /// Produces diagnostics and sends a `PublishDiagnostics` notification to the client

--- a/src/test.rs
+++ b/src/test.rs
@@ -46,6 +46,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -71,6 +72,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -96,6 +98,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -121,6 +124,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -146,6 +150,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -171,6 +176,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -196,6 +202,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 
@@ -221,6 +228,7 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             },
+            client: None,
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -874,6 +874,7 @@ pub struct Config {
     pub assemblers: Assemblers,
     pub instruction_sets: InstructionSets,
     pub opts: ConfigOptions,
+    pub client: Option<LspClient>,
 }
 
 impl Default for Config {
@@ -883,8 +884,14 @@ impl Default for Config {
             assemblers: Assemblers::default(),
             instruction_sets: InstructionSets::default(),
             opts: ConfigOptions::default(),
+            client: None,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LspClient {
+    Helix,
 }
 
 // Instruction Set Architecture -------------------------------------------------------------------


### PR DESCRIPTION
Whenever the server doesn't have an answer for a request (for example, you hover over something that it doesn't have information for), it sends an empty response. This looks like the following:


```rust
Response {
    id, // id passed in for the corresponding request
    result: None,
    error: None,
};
```

When this response is sent to the [Helix](https://github.com/helix-editor/helix) LSP client, it shuts down the server with the following log:

```
[ERROR] Exiting asm-lsp after unexpected error: Parse(Error("data did not match any variant of untagged enum ServerMessage", line: 0, column: 0))
```

The easy solution for this is to detect if the lsp-client is helix at server start, and store that information in our `Config` object. If the client is helix and an empty response is going to be sent, we send nothing instead.

Closes #148