### PR TITLE
Update example config to use the zig compiler for `compile_flags.txt` generated diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ arm = false
 riscv = false
 
 [opts]
-#compiler = "gcc"
+compiler = "zig" # need "cc" as the first argument in `compile_flags.txt`
 diagnostics = true
 default_diagnostics = true
 ```


### PR DESCRIPTION
Because zig is awesome