### PR TITLE
fix(CI): precommit hooks ruby dependency

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -43,6 +43,16 @@ jobs:
           ruby-version: '3.1'
           msys2: true
 
+      - name: Install Ruby on Ubuntu
+        if: runner.os == 'Linux'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Setup Ruby on Ubuntu
+        if: runner.os == 'Linux'
+        run: sudo ln -s "$(which ruby)" /usr/bin/ruby3.2
+
       - name: Install pre-commit dependencies
         run: python -m pip install pre-commit
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1671,7 +1671,9 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     if let Some(folders) = &params.workspace_folders {
         // if there's multiple, just visit in order until we find a valid folder
         for folder in folders {
+            #[allow(irrefutable_let_patterns)]
             if let Ok(parsed) = PathBuf::from_str(folder.uri.path().as_str()) {
+                #[allow(irrefutable_let_patterns)]
                 if let Ok(parsed_path) = parsed.canonicalize() {
                     info!("Detected project root: {}", parsed_path.display());
                     return Some(parsed_path);
@@ -1682,8 +1684,11 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
 
     // if workspace folders weren't set or came up empty, we check the root_uri
     #[allow(deprecated)]
+    #[allow(irrefutable_let_patterns)]
     if let Some(root_uri) = &params.root_uri {
+        #[allow(irrefutable_let_patterns)]
         if let Ok(parsed) = PathBuf::from_str(root_uri.path().as_str()) {
+            #[allow(irrefutable_let_patterns)]
             if let Ok(parsed_path) = parsed.canonicalize() {
                 info!("Detected project root: {}", parsed_path.display());
                 return Some(parsed_path);
@@ -1694,6 +1699,7 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     // if both `workspace_folders` and `root_uri` weren't set or came up empty, we check the root_path
     #[allow(deprecated)]
     if let Some(root_path) = &params.root_path {
+        #[allow(irrefutable_let_patterns)]
         if let Ok(parsed) = PathBuf::from_str(root_path.as_str()) {
             if let Ok(parsed_path) = parsed.canonicalize() {
                 return Some(parsed_path);


### PR DESCRIPTION
Ran into some issues with CI while testing #158. Going to merge this in now to prevent future headaches, shouldn't cause any conflicts with open PRs.

EDIT: cc @Ultra-Code I have to disable some lints in order for CI to pass here. I think it's a false positive since taking the lint's suggestion results in a compile error (`PathBuf`'s `core::convert::Infallible` error type isn't treated as infallible for me locally at least), so I may be introducing a few conflicts. CI has to pass in order for your PR to get in, but regardless my apologies.