### PR TITLE
chore: cleanup around irrefutable let patterns

### DIFF
--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -1872,10 +1872,7 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     if let Some(folders) = &params.workspace_folders {
         // if there's multiple, just visit in order until we find a valid folder
         for folder in folders {
-            #[allow(irrefutable_let_patterns)] // TODO: Remove once CI is bumped past 1.82
-            let Ok(parsed) = PathBuf::from_str(folder.uri.path().as_str()) else {
-                unreachable!()
-            };
+            let Ok(parsed) = PathBuf::from_str(folder.uri.path().as_str());
             if let Ok(parsed_path) = parsed.canonicalize() {
                 info!("Detected project root: {}", parsed_path.display());
                 return Some(parsed_path);
@@ -1886,10 +1883,7 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     // if workspace folders weren't set or came up empty, we check the root_uri
     #[allow(deprecated)]
     if let Some(root_uri) = &params.root_uri {
-        #[allow(irrefutable_let_patterns)] // TODO: Remove once CI is bumped past 1.82
-        let Ok(parsed) = PathBuf::from_str(root_uri.path().as_str()) else {
-            unreachable!()
-        };
+        let Ok(parsed) = PathBuf::from_str(root_uri.path().as_str());
         if let Ok(parsed_path) = parsed.canonicalize() {
             info!("Detected project root: {}", parsed_path.display());
             return Some(parsed_path);
@@ -1899,10 +1893,7 @@ fn get_project_root(params: &InitializeParams) -> Option<PathBuf> {
     // if both `workspace_folders` and `root_uri` weren't set or came up empty, we check the root_path
     #[allow(deprecated)]
     if let Some(root_path) = &params.root_path {
-        #[allow(irrefutable_let_patterns)] // TODO: Remove once CI is bumped past 1.82
-        let Ok(parsed) = PathBuf::from_str(root_path.as_str()) else {
-            unreachable!()
-        };
+        let Ok(parsed) = PathBuf::from_str(root_path.as_str());
         if let Ok(parsed_path) = parsed.canonicalize() {
             return Some(parsed_path);
         }


### PR DESCRIPTION
Follow up from #160 and #156.

Now that we have the latest stable running in CI, we can clean up some of the noise around irrefutable let patterns, which we previously had to manually ignore with a clippy annotation.