### PR TITLE
feat: Config builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,9 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "clap",
  "compile_commands",
+ "dialoguer",
  "dirs",
  "flexi_logger",
  "home",
@@ -358,6 +360,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +443,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +505,12 @@ checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -630,6 +665,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1730,6 +1774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2044,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2223,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ license = "BSD-2-Clause"
 [workspace.dependencies]
 anyhow = "1.0.86"
 bincode = "1.3.3"
+dirs = "5.0.1"
+toml = "0.8.1"
+clap = { version = "4.5.8", features = ["derive", "cargo"] }
 serde = { version = "1.0.204", features = ["derive"] }
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ created for different sub-directories or files within your project as `project`s
 Source files not contained within any `project` configs will use the default configuration
 if provided.
 
+#### Config Builder
+
+Creating a `.asm-lsp.toml` file manually is fine, but can be error-prone as projects
+grow in complexity. Running `asm-lsp gen-config` will walk you through the creation
+of a config interactively, with informative prompts and extra validation checks
+along the way.
+
+```
+$ asm-lsp gen-config --help
+Generate a .asm-lsp.toml config file
+
+Usage: asm-lsp gen-config [OPTIONS]
+
+Options:
+  -o, --output-dir <OUTPUT_DIR>      Directory to place .asm-lsp.toml into. (Default is the current directory)
+  -g, --global-cfg                   Place the config in the global config directory
+  -p, --project-path <PROJECT_PATH>  Path to the project this config is being generated for. (Default is the current directory)
+  -w, --overwrite                    Overwrite any existing .asm-lsp.toml in the target directory
+  -q, --quiet                        Don't display the generated config file after generation
+  -h, --help                         Print help
+```
+
 #### NOTE
 
 If the server reads in an invalid configuration file, it will display an error

--- a/asm-lsp/Cargo.toml
+++ b/asm-lsp/Cargo.toml
@@ -25,6 +25,9 @@ path = "bin/main.rs"
 anyhow.workspace = true
 bincode.workspace = true
 serde.workspace = true
+dirs.workspace = true
+toml.workspace = true
+clap.workspace = true
 # write to stderr instead of stdout
 flexi_logger = "0.29.3"
 log = { version = "0.4.17" }
@@ -35,10 +38,8 @@ reqwest = { version = "0.12.8", features = ["blocking"] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
 serde_json = "1.0.94"
-toml = "0.8.1"
 home = "0.5.5"
 once_cell = "1.18.0"
-dirs = "5.0.1"
 symbolic = { version = "12.8.0", features = ["demangle"] }
 symbolic-demangle = "12.8.0"
 url-escape = "0.1.1"
@@ -47,6 +48,7 @@ lsp-textdocument = "0.4.0"
 tree-sitter = "0.22.6"
 tree-sitter-asm = "0.22.6"
 compile_commands = "0.3.0"
+dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/asm-lsp/config_builder.rs
+++ b/asm-lsp/config_builder.rs
@@ -1,0 +1,468 @@
+use std::process::Command;
+use std::string::ToString;
+use std::{env::current_dir, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+use clap::{arg, Args};
+use dirs::config_dir;
+
+use crate::types::{Arch, Assembler, Config, ConfigOptions, ProjectConfig, RootConfig};
+
+use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input};
+
+const ARCH_LIST: [Arch; 7] = [
+    Arch::X86,
+    Arch::X86_64,
+    Arch::X86_AND_X86_64,
+    Arch::ARM,
+    Arch::ARM64,
+    Arch::RISCV,
+    Arch::Z80,
+];
+
+const ASSEMBLER_LIST: [Assembler; 4] = [
+    Assembler::Gas,
+    Assembler::Go,
+    Assembler::Masm,
+    Assembler::Nasm,
+];
+
+#[derive(Args, Debug, Clone)]
+#[command(about = "Generate a .asm-lsp.toml config file")]
+pub struct GenerateArgs {
+    #[arg(
+        long,
+        short,
+        help = "Directory to place .asm-lsp.toml into. (Default is the current directory)"
+    )]
+    pub output_dir: Option<PathBuf>,
+    #[arg(
+        long,
+        short,
+        conflicts_with = "output_dir",
+        help = "Place the config in the global config directory"
+    )]
+    pub global_cfg: bool,
+    #[arg(
+        long,
+        short,
+        conflicts_with = "global_cfg",
+        help = "Path to the project this config is being generated for. (Default is the current directory)"
+    )]
+    pub project_path: Option<PathBuf>,
+    #[arg(
+        short = 'w',
+        long,
+        help = "Overwrite any existing .asm-lsp.toml in the target directory"
+    )]
+    pub overwrite: bool,
+    #[arg(
+        short,
+        long,
+        help = "Don't display the generated config file after generation"
+    )]
+    pub quiet: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct GenerateOpts {
+    pub output_path: PathBuf,
+    pub project_path: PathBuf,
+    pub overwrite: bool,
+    pub quiet: bool,
+}
+
+impl TryFrom<GenerateArgs> for GenerateOpts {
+    type Error = String;
+    fn try_from(value: GenerateArgs) -> Result<Self, std::string::String> {
+        let output_path = {
+            if value.global_cfg {
+                let mut path = config_dir().ok_or_else(|| "Failed to detect config directory, try specifying it manually with `--output_dir`".to_string())?;
+                path.push("asm-lsp");
+                path.push(".asm-lsp.toml");
+                path
+            } else if let Some(path) = value.output_dir {
+                let mut canonicalized_path = path.canonicalize().map_err(|e| {
+                    format!(
+                        "Failed to canonicalize target path: \"{}\" -- {e}",
+                        path.display()
+                    )
+                })?;
+                if !canonicalized_path.is_dir() {
+                    let gave_file_name = canonicalized_path.ends_with(".asm-lsp.toml");
+                    return Err(format!(
+                        "Target path \"{}\" is not a directory.{}",
+                        canonicalized_path.display(),
+                        if gave_file_name {
+                            " Hint: Don't include the filename \".asm-lsp.toml\" at the end of your target path."
+                        } else {
+                            ""
+                        }
+                    ));
+                }
+                canonicalized_path.push(".asm-lsp.toml");
+                canonicalized_path
+            } else {
+                let mut path = current_dir()
+                    .map_err(|e| format!("Failed to detect current directory -- {e}"))?;
+                path.push(".asm-lsp.toml");
+                path
+            }
+        };
+        let project_path = {
+            if let Some(path) = value.project_path {
+                let canonicalized_path = path.canonicalize().map_err(|e| {
+                    format!(
+                        "Failed to canonicalize project path: \"{}\" -- {e}",
+                        path.display()
+                    )
+                })?;
+                if !canonicalized_path.is_dir() {
+                    return Err(format!(
+                        "Project path \"{}\" is not a directory.",
+                        canonicalized_path.display(),
+                    ));
+                }
+                canonicalized_path
+            } else {
+                current_dir().map_err(|e| format!("Failed to detect current directory -- {e}"))?
+            }
+        };
+
+        Ok(Self {
+            output_path,
+            project_path,
+            overwrite: value.overwrite,
+            quiet: value.quiet,
+        })
+    }
+}
+
+fn prompt_arch() -> Arch {
+    let arch_choices: Vec<String> = ARCH_LIST.iter().map(ToString::to_string).collect();
+    let arch_selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select architecture")
+        .default(0)
+        .items(&arch_choices[..])
+        .interact()
+        .unwrap();
+
+    ARCH_LIST[arch_selection]
+}
+
+fn prompt_assembler() -> Assembler {
+    let assem_choices: Vec<String> = ASSEMBLER_LIST.iter().map(ToString::to_string).collect();
+    let assem_selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select assembler")
+        .default(0)
+        .items(&assem_choices[..])
+        .interact()
+        .unwrap();
+
+    ASSEMBLER_LIST[assem_selection]
+}
+
+fn prompt_project_path(opts: &GenerateOpts) -> PathBuf {
+    println!("Provide a project path:");
+    let fallback_enter = |true_path: &mut PathBuf| {
+        println!(
+            "Warning: Failed to create directory reader for path \"{}\"",
+            true_path.display()
+        );
+        let remaining_path: String = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Enter remaining path (Enter an empty string to use the current path)")
+            .allow_empty(true)
+            .interact_text()
+            .unwrap();
+        true_path.push(remaining_path);
+    };
+    let mut true_path = opts.project_path.clone();
+    let mut display_entries = Vec::new();
+    let mut path_entries = Vec::new();
+    loop {
+        let selection_text = format!("{}", true_path.display());
+        // Dummy entry to account for the accept option as the first displayed
+        // option
+        path_entries.push(PathBuf::new());
+        display_entries.push("<Select This Directory>".to_string());
+        let Ok(dir_reader) = std::fs::read_dir(&true_path) else {
+            fallback_enter(&mut true_path);
+            return true_path;
+        };
+        for entry in dir_reader.filter_map(std::result::Result::ok) {
+            let entry_path = entry.path();
+            path_entries.push(entry_path.clone());
+            if let Some(name) = entry_path.file_name() {
+                display_entries.push(name.to_string_lossy().to_string());
+            }
+        }
+        let path_selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(&selection_text)
+            .default(0)
+            .items(&display_entries[..])
+            .interact()
+            .unwrap();
+
+        // Select current value of `true_path`
+        if path_selection == 0 {
+            if true_path.to_string_lossy().len() == opts.project_path.to_string_lossy().len() &&
+                !Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Warning: Creating project config for the entire project. Keep this path selection?")
+                    .default(false)
+                    .interact()
+                    .unwrap() {
+                       continue;
+            }
+            break;
+        }
+
+        true_path.clone_from(&path_entries[path_selection]);
+        if true_path.is_file() {
+            break;
+        }
+        path_entries.clear();
+        display_entries.clear();
+    }
+
+    // Get the project-relative path out for the sake of portability, i.e. if a
+    // user changes the location of their project, their config should still work
+    let mut relative_path = PathBuf::new();
+    for comp in true_path
+        .components()
+        .skip(opts.project_path.components().count())
+    {
+        relative_path.push(comp);
+    }
+
+    relative_path
+}
+
+fn prompt_project(opts: &GenerateOpts) -> ProjectConfig {
+    let path = prompt_project_path(opts);
+    let config = prompt_config();
+
+    ProjectConfig { path, config }
+}
+
+fn prompt_compiler() -> Option<String> {
+    if !Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Provide compiler to use with `compile_flags.txt` files or the following (optional) compile flags field")
+        .default(true)
+        .interact()
+        .unwrap() {
+        return None;
+    }
+    let mut comp: String;
+    loop {
+        comp = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Enter Compiler")
+            .interact_text()
+            .unwrap();
+
+        // Attempt to provide some soft validation, warn the user if something
+        // looks fishy
+        let looks_ok = if comp.contains('/') {
+            // Treat it as a path, try checking if it exists
+            let path = PathBuf::from(&comp);
+            let exists = path.exists();
+            let is_file = path.is_file();
+            if !exists {
+                println!(
+                    "Warning: File does not exist at path \"{}\"",
+                    path.display()
+                );
+            } else if !is_file {
+                println!(
+                    "Warning: Path \"{}\" does not point to a file",
+                    path.display()
+                );
+            }
+            exists && is_file
+        } else {
+            // TODO: Find a less hacky, reasonably performant way to validate this
+            let find_cmd = if cfg!(target_os = "windows") {
+                "where"
+            } else {
+                "which"
+            };
+            if let Ok(result) = Command::new(find_cmd).arg(&comp).output() {
+                let success = result.status.success();
+                if !success {
+                    println!("Warning: Unable to confirm \"{comp}\" as an executable on path");
+                }
+                success
+            } else {
+                println!("Warning: Failed to run compiler validation");
+                false
+            }
+        };
+        if looks_ok
+            || !Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Re-enter compiler?")
+                .default(true)
+                .interact()
+                .unwrap()
+        {
+            break;
+        }
+    }
+
+    Some(comp)
+}
+
+fn prompt_config_opts() -> ConfigOptions {
+    let compiler = prompt_compiler();
+    // If the user specifies a compiler in their config, it makes sense to provide
+    // corresponding flags.
+    let compile_flags_txt = if compiler.is_some() {
+        let mut flags = Vec::new();
+        loop {
+            let flag: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt("Add a compiler flag: (Enter an empty string to stop)")
+                .allow_empty(true)
+                .validate_with(|input: &String| -> Result<()> {
+                    // NOTE: Do we need to handle escaped quotes here?
+                    let mut in_quotes = false;
+                    for (i, c) in input.chars().enumerate() {
+                        match c {
+                            '\"' => in_quotes = !in_quotes,
+                            ' ' => {
+                                if !in_quotes {
+                                    return Err(anyhow!(
+                                        "\n{input}\n{}^\nUnquoted space found, specify each flag separately.",
+                                        " ".repeat(i),
+                                    ));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    Ok(())
+                })
+                .interact_text()
+                .unwrap();
+            if flag.is_empty() {
+                break;
+            }
+            flags.push(flag);
+        }
+        Some(flags)
+    } else {
+        None
+    };
+
+    let diagnostics = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enable diagnostic features?")
+        .default(true)
+        .interact()
+        .unwrap();
+
+    // only offer the `default_diagnostics` option if both
+    //      A) diagnostics are enabled
+    //      B) The user didn't specify compiler instructions via the `compiler`
+    //         field (if they did so, default diagnostics will never be used)
+    let default_diagnostics = if diagnostics && compiler.is_none() && Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Attempt to provide diagnostics if no compilation information can be found for a source file?")
+        .default(true)
+        .interact()
+        .unwrap() {
+            Some(true)
+    } else {
+        Some(false)
+    };
+
+    ConfigOptions {
+        compiler,
+        compile_flags_txt,
+        diagnostics: Some(diagnostics),
+        default_diagnostics,
+    }
+}
+
+fn prompt_config() -> Config {
+    let instruction_set = prompt_arch();
+    let assembler = prompt_assembler();
+    let opts = if Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Configure diagnostic related features?")
+        .default(true)
+        .interact()
+        .unwrap()
+    {
+        Some(prompt_config_opts())
+    } else {
+        None
+    };
+
+    Config {
+        version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        instruction_set,
+        assembler,
+        opts,
+        client: None,
+    }
+}
+
+fn prompt_root_config(opts: &GenerateOpts) -> RootConfig {
+    let default_config = if Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Create default config?")
+        .interact()
+        .unwrap()
+    {
+        Some(prompt_config())
+    } else {
+        None
+    };
+
+    let mut projects = Vec::new();
+    loop {
+        if !Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Add a new project config?")
+            .interact()
+            .unwrap()
+        {
+            break;
+        }
+        projects.push(prompt_project(opts));
+    }
+
+    RootConfig {
+        default_config,
+        projects: if projects.is_empty() {
+            None
+        } else {
+            Some(projects)
+        },
+    }
+}
+
+/// Prompts the user through generating a `.asm-lsp.toml` config file
+///
+/// # Errors
+///
+/// Returns `Err` if
+///     - A config file exists and the `--overwrite` flag wasn't used
+///     - An error occurs during config generation
+///     - Serialization of the generated config fails
+///     - Writing the serialized config to a file fails
+pub fn gen_config(opts: &GenerateOpts) -> Result<()> {
+    if !opts.overwrite && opts.output_path.exists() {
+        return Err(anyhow!(
+            "The target path \"{}\" already exists and `--overwrite` was not used",
+            opts.output_path.display()
+        ));
+    }
+    let root_config = prompt_root_config(opts);
+    let file_config = toml::to_string_pretty::<RootConfig>(&root_config).map_err(|e| {
+        anyhow!("Failed to serialize configuration -- {e}\nPlease file a bug report: https://github.com/bergercookie/asm-lsp/issues/new")
+    })?;
+    if !opts.quiet {
+        println!("{file_config}");
+    }
+    std::fs::write(&opts.output_path, file_config).map_err(|e| {
+        anyhow!(
+            "Failed to write config file to path \"{}\" -- {e}",
+            opts.output_path.display()
+        )
+    })?;
+    Ok(())
+}

--- a/asm-lsp/lib.rs
+++ b/asm-lsp/lib.rs
@@ -1,3 +1,4 @@
+pub mod config_builder;
 pub mod handle;
 pub mod lsp;
 pub mod parser;

--- a/asm_docs_parsing/Cargo.toml
+++ b/asm_docs_parsing/Cargo.toml
@@ -13,8 +13,8 @@ edition.workspace = true
 bincode.workspace = true
 anyhow.workspace = true
 serde.workspace = true
+clap.workspace = true
 asm-lsp = { path = "../asm-lsp" }
-clap = { version = "4.5.8", features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
I am greatly excited by the config improvements coming from #158. These changes do make the config a bit more complex though, which may be confusing/hard to track in large projects/ for new users. This PR adds a small CLI program that prompts a user through creating a `.asm-lsp.toml` config file, which should help manage that complexity. ~~I'll add some more details to this PR description (and some example gifs) once it's closer to being merged, but I wanted to open this up early for the sake of visibility.~~

~~Currently, the config builder program lives as a separate binary crate within the project. I think I'd like to change this to run as a subcommand of the main program (assuming it doesn't bloat the binary size by too much). Some documentation for this also needs to be added to the project's README.~~

Here's an example gif. I don't currently have a large assembly project to demonstrate this on, so I'm just going to run the tool within the `asm-lsp` repo selecting some nonsense options:

![ConfigBuilder](https://github.com/user-attachments/assets/59c8c9ee-9d03-45c0-b8ce-c14fe934115f)

(The flickering only shows up in the recording, I'm not entirely sure what's causing that)

The builder provides validation for selected options in the following ways:

- Any enum field specified (i.e. arch or assembler) will be valid
- project paths will point to valid directories or files on the system. After selection, the builder translates the absolute path to one relative to the project's root directory (for portability reasons)
- For any compiler specified, a check is made to ensure it is a valid path to an executable file, or that it can be found on `$PATH`.
- Project configs are checked for redundant paths

Closes #161