### PR TITLE
fix(CI): remove race-y code from tests

### DIFF
--- a/asm-lsp/test.rs
+++ b/asm-lsp/test.rs
@@ -282,12 +282,6 @@ mod tests {
     fn init_test_store(info: &GlobalInfo) -> ServerStore {
         let mut store = ServerStore::default();
 
-        let mut x86_cache_path = get_cache_dir().unwrap();
-        x86_cache_path.push("x86_instr_docs.html");
-        if x86_cache_path.is_file() {
-            std::fs::remove_file(&x86_cache_path).unwrap();
-        }
-
         populate_name_to_instruction_map(
             Arch::X86,
             &info.x86_instructions,


### PR DESCRIPTION
This ended up being a lot simpler than I initially thought. In our tests' setup code, we have the following race condition:

```rust
fn init_test_store(info: &GlobalInfo) -> ServerStore {
    let mut store = ServerStore::default();

    let mut x86_cache_path = get_cache_dir().unwrap();
    x86_cache_path.push("x86_instr_docs.html");
    if x86_cache_path.is_file() {
        std::fs::remove_file(&x86_cache_path).unwrap(); // BAD CODE HERE!
    }
    ...
}
```

With tests running on multiple threads, it's possible for one to check that the cache file exists, be interrupted, and after it's resumed a test runner on another thread has already removed it. This cache was in the test code because we used to pull this file down from the internet at the server's start. Some caching for it was added in #21, so it made sense to clear out the cache so we'd have to test grabbing a fresh copy everytime. Now, all of our docs are serialized, so there's no reason to keep this around.

Closes #167 