### PR TITLE
fix(config builder): compiler validation on windows

### DIFF
--- a/asm-lsp/config_builder.rs
+++ b/asm-lsp/config_builder.rs
@@ -279,6 +279,24 @@ fn is_executable(path: &Path) -> bool {
             false
         }
     } else {
+        #[cfg(windows)]
+        {
+            // On Windows, it's valid to omit file extensions, i.e. `gcc` can be
+            // used to designate `gcc.exe`. However, this will cause `.is_file()`
+            // to return `false`, so we need to check for this case here rather
+            // than above
+            let extensions = ["exe", "cmd", "bat", "com"];
+            for ext in &extensions {
+                let Some(path) = path.to_str() else {
+                    continue;
+                };
+                let ext_path = PathBuf::from(format!("{path}.{ext}"));
+                if ext_path.exists() && ext_path.is_file() {
+                    println!("Warning: Extended provided path with \".{ext}\" in order to find valid compiler");
+                    return true;
+                }
+            }
+        }
         false
     }
 }


### PR DESCRIPTION
The basic problem here is that windows allows you to omit a file name when referring to a file. That is, `gcc` is perfectly fine to refer to `gcc.exe`. However, calling `.is_file()` on a path ending with `gcc` where the file is actually `gcc.exe` will return `false`. This causes a bug in our compiler validation logic on Windows, leading us to tell users that their compiler couldn't be found when it definitely was. 

The fix is to simply iterate over common executable extension when the `is_file()` check fails. If any of these extension paths exist and point to a file, we'll consider that good enough:tm: and treat it as a valid compiler path. We'll still print a warning to the screen in this case, to avoid potential confusion.

Addresses the main issue raised in #173 