### PR TITLE
fix(docs): clarify usage of config fields in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,14 @@ message and exit.
 
 ```toml
 [default_config]
+# Configure documentation available for features like hover and completions
 assembler = "go"
 instruction_set = "x86/x86-64"
 
 [opts]
+# The `compiler` field is the name of a compiler/assembler on your path
+# (or the absolute path to the file) that is used to build your source files
+# This program will be used to generate diagnostics
 compiler = "zig" # need "cc" as the first argument in `compile_flags.txt`
 diagnostics = true
 default_diagnostics = true


### PR DESCRIPTION
Without the necessary background, it can be unclear what the various config fields do. Adding these comments in the README's example should help clear things up.

Closes  #174