### PR TITLE
fix: Remove leading slash from paths on windows with colon drive separators

### DIFF
--- a/asm-lsp/types.rs
+++ b/asm-lsp/types.rs
@@ -1011,7 +1011,7 @@ impl RootConfig {
             UriConversion::Canonicalized(p) => p,
             UriConversion::Unchecked(p) => {
                 warn!(
-                    "Failed to canonicalized request path {}, using {}",
+                    "Failed to canonicalize request path {}, using {}",
                     req_uri.path().as_str(),
                     p.display()
                 );


### PR DESCRIPTION
After dealing with a number of issues surrounding how paths are communicated from various lsp clients on Windows, I believe this should fix #173. The basic idea is this:

1. We see a leading slash '/' on a path on Windows
2. We see that the path contains a drive separator, ':' (this check is performed *after* percent decoding)
3. Remove the leading slash

Feels a little hacky, but in theory we should have a valid path after that.

@elli0t43 I don't currently have a full setup on Windows to test this with. I can get to that eventually, but if you have the time to test this fix that could really expedite things and would be greatly appreciated. :)