### PR TITLE
chore: add compile command log, remove pretty formatting from other logs

### DIFF
--- a/asm-lsp/bin/main.rs
+++ b/asm-lsp/bin/main.rs
@@ -241,7 +241,7 @@ fn main_loop(connection: &Connection, config: &RootConfig, store: &ServerStore) 
             Message::Notification(notif) => {
                 handle_notification(notif, connection, &mut doc_store, config, store)?;
             }
-            Message::Response(resp) => warn!("Unexpected client response: {resp:#?}"),
+            Message::Response(resp) => warn!("Unexpected client response: {resp:?}"),
         }
     }
     Ok(())

--- a/asm-lsp/handle.rs
+++ b/asm-lsp/handle.rs
@@ -155,7 +155,7 @@ pub fn handle_request(
                     &store.compile_commands,
                 );
                 info!(
-                    "Selected compile command(s) for request: {:#?}",
+                    "Selected compile command(s) for request: {:?}",
                     compile_cmds
                 );
                 handle_diagnostics(
@@ -171,7 +171,7 @@ pub fn handle_request(
                 );
             }
         }
-        method => warn!("Invalid request format: {method:#?}"),
+        method => warn!("Invalid request format: {method:?}"),
     }
 
     Ok(())
@@ -238,7 +238,7 @@ pub fn handle_notification(
                     &store.compile_commands,
                 );
                 info!(
-                    "Selected compile command(s) for request: {:#?}",
+                    "Selected compile command(s) for request: {:?}",
                     compile_cmds
                 );
                 handle_diagnostics(
@@ -253,7 +253,7 @@ pub fn handle_notification(
                 );
             }
         }
-        method => warn!("Invalid notification format: {method:#?}"),
+        method => warn!("Invalid notification format: {method:?}"),
     }
     Ok(())
 }

--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -589,6 +589,7 @@ pub fn apply_compile_cmd(
     uri: &Uri,
     compile_cmd: &CompileCommand,
 ) {
+    info!("Attempting to apply compile command: {compile_cmd:?}");
     // TODO: Consolidate this logic, a little tricky because we need to capture
     // compile_cmd.arguments by reference, but we get an owned Vec out of args_from_cmd()...
     if let Some(ref args) = compile_cmd.arguments {


### PR DESCRIPTION
Two quick changes here.

1. Add a log about what compile command the server is attempting to invoke.

2. The extra formatting used in `:#?`-style debug logs aren't better compared to `:?` when used inside of neovim lsp log file, so I've swapped them out.