### PR TITLE
fix: Remove `pub` marker from `ustr` and `lsp` mods

### DIFF
--- a/asm-lsp/lib.rs
+++ b/asm-lsp/lib.rs
@@ -1,10 +1,10 @@
 pub mod config_builder;
 pub mod handle;
-pub mod lsp;
+mod lsp;
 pub mod parser;
 mod test;
 pub mod types;
-pub mod ustr;
+mod ustr;
 
 pub use lsp::*;
 pub use parser::{

--- a/asm-lsp/ustr.rs
+++ b/asm-lsp/ustr.rs
@@ -2,11 +2,23 @@
 //! input unnecessarily and from my survey our inputs are mostly ascii
 use std::str;
 
+/// Converts a byte slice to a string slice without checking for valid UTF-8.
+///
+/// # Safety
+///
+/// The caller must ensure that the input slice is valid UTF-8. Passing invalid UTF-8
+/// to this function invokes undefined behavior.
 #[must_use]
 pub const fn get_str(v: &[u8]) -> &str {
     unsafe { str::from_utf8_unchecked(v) }
 }
 
+/// Converts a byte vector to a string without checking for valid UTF-8.
+///
+/// # Safety
+///
+/// The caller must ensure that the input vector is valid UTF-8. Passing invalid UTF-8
+/// to this function invokes undefined behavior.
 #[must_use]
 pub fn get_string(v: Vec<u8>) -> String {
     unsafe { String::from_utf8_unchecked(v) }


### PR DESCRIPTION
Closes #187 