### PR TITLE
chore(gh): Add a `.gitattributes` file 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-vendored


### PR DESCRIPTION
In theory, with this change Github will ignore the html files we have in `docs_store` when calculating language stats for the repo.