### PR TITLE
update/remove some logging

### DIFF
--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -1297,9 +1297,8 @@ pub fn get_comp_resp(
                 if cap.node.end_byte() >= curr_doc.len() {
                     continue;
                 }
-                match cap.node.utf8_text(curr_doc) {
-                    Ok(text) => _ = labels.insert(text),
-                    Err(_) => continue,
+                if let Ok(text) = cap.node.utf8_text(curr_doc) {
+                    labels.insert(text);
                 }
             }
         }


### PR DESCRIPTION
The server's `populate_*` functions used to run at server startup time, so logging errors through the lsp client was useful. Since these functions are only called beforehand at serialization, it doesn't make sense to log information anymore. I've removed most instances, and converted the others to prints so we can see the output in the case of a failing test.

This PR also includes a few random spot fixes/cleanups.