### PR TITLE
fix(config-builder): clear path lists in edge case, do some maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,6 @@ dependencies = [
  "lsp-textdocument",
  "lsp-types",
  "mockito",
- "once_cell",
  "quick-xml",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -459,23 +459,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.29.8"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5a6882b2e137c4f2664562995865084eb5a00611fba30c582ef10354c4ad8"
+checksum = "fcd71620581c99445892ad71e2c2e0d6f62edf2e22822556f0d2ee9f8508af29"
 dependencies = [
  "chrono",
  "log",
@@ -697,7 +697,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
 ]
@@ -1626,13 +1626,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2016,15 +2016,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2613,7 +2613,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2643,16 +2643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2661,7 +2652,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2670,22 +2661,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2694,21 +2670,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2718,21 +2688,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2748,21 +2706,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2772,21 +2718,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "BSD-2-Clause"
 [workspace.dependencies]
 anyhow = "1.0.86"
 bincode = "1.3.3"
-dirs = "5.0.1"
+dirs = "6.0.0"
 toml = "0.8.1"
 clap = { version = "4.5.8", features = ["derive", "cargo"] }
 serde = { version = "1.0.204", features = ["derive"] }

--- a/asm-lsp/Cargo.toml
+++ b/asm-lsp/Cargo.toml
@@ -29,21 +29,22 @@ dirs.workspace = true
 toml.workspace = true
 clap.workspace = true
 # write to stderr instead of stdout
-flexi_logger = "0.29.3"
+flexi_logger = "0.30.1"
 log = { version = "0.4.17" }
 lsp-server = "0.7.6"
 lsp-types = "0.97.0"
 regex = "1.7.2"
 reqwest = { version = "0.12.8", features = ["blocking"] }
-strum = "0.26.3"
-strum_macros = "0.26.4"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 serde_json = "1.0.94"
 home = "0.5.5"
 symbolic = { version = "12.8.0", features = ["demangle"] }
 symbolic-demangle = "12.8.0"
 url-escape = "0.1.1"
-quick-xml = "0.36.2"
+quick-xml = "0.37.4"
 lsp-textdocument = "0.4.0"
+# TODO: Upgrade to 0.25.3
 tree-sitter = "0.22.6"
 tree-sitter-asm = "0.22.6"
 compile_commands = "0.3.0"

--- a/asm-lsp/Cargo.toml
+++ b/asm-lsp/Cargo.toml
@@ -39,7 +39,6 @@ strum = "0.26.3"
 strum_macros = "0.26.4"
 serde_json = "1.0.94"
 home = "0.5.5"
-once_cell = "1.18.0"
 symbolic = { version = "12.8.0", features = ["demangle"] }
 symbolic-demangle = "12.8.0"
 url-escape = "0.1.1"

--- a/asm-lsp/config_builder.rs
+++ b/asm-lsp/config_builder.rs
@@ -4,11 +4,10 @@ use std::{env::current_dir, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 use clap::{arg, Args};
+use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input};
 use dirs::config_dir;
 
 use crate::types::{Arch, Assembler, Config, ConfigOptions, ProjectConfig, RootConfig};
-
-use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input};
 
 const ARCH_LIST: [Arch; 10] = [
     Arch::X86,

--- a/asm-lsp/config_builder.rs
+++ b/asm-lsp/config_builder.rs
@@ -230,7 +230,9 @@ fn prompt_project_path(opts: &GenerateOpts) -> PathBuf {
                     .default(false)
                     .interact()
                     .unwrap() {
-                       continue;
+                path_entries.clear();
+                display_entries.clear();
+                continue;
             }
             break;
         }

--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -1,16 +1,17 @@
-use crate::{ustr, CompletionItems, DocumentStore, Hoverable, ServerStore};
-use std::borrow::ToOwned;
-use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
-use std::fmt::Write as _;
-use std::fs::{create_dir_all, File};
-use std::io::BufRead;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::str::FromStr;
-use std::string::ToString;
-use std::sync::LazyLock;
+use std::{
+    borrow::ToOwned,
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    convert::TryFrom as _,
+    fmt::Write as _,
+    fs::{create_dir_all, File},
+    io::BufRead,
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr as _,
+    string::ToString as _,
+    sync::LazyLock,
+};
 
 use anyhow::{anyhow, Result};
 use compile_commands::{CompilationDatabase, CompileArgs, CompileCommand, SourceFile};
@@ -32,10 +33,10 @@ use symbolic::common::{Language, Name, NameMangling};
 use symbolic_demangle::{Demangle, DemangleOptions};
 use tree_sitter::InputEdit;
 
-use crate::types::Column;
 use crate::{
-    Arch, ArchOrAssembler, Assembler, Completable, Config, ConfigOptions, Directive, Instruction,
-    LspClient, NameToInstructionMap, RootConfig, TreeEntry,
+    types::Column, ustr, Arch, ArchOrAssembler, Assembler, Completable, CompletionItems, Config,
+    ConfigOptions, Directive, DocumentStore, Hoverable, Instruction, LspClient,
+    NameToInstructionMap, RootConfig, ServerStore, TreeEntry,
 };
 
 /// Prints information about the server

--- a/asm-lsp/parser.rs
+++ b/asm-lsp/parser.rs
@@ -1,18 +1,12 @@
-use crate::{ustr, AvrStatusRegister, AvrTiming};
-use std::collections::HashMap;
-use std::env::args;
-use std::fs;
-use std::io::Write;
-use std::iter::Peekable;
-use std::path::PathBuf;
-use std::str::{FromStr, Lines};
-
-use crate::types::{
-    Arch, Assembler, Directive, Instruction, InstructionForm, MMXMode, NameToDirectiveMap,
-    NameToInstructionMap, NameToRegisterMap, Operand, OperandType, Register, RegisterBitInfo,
-    RegisterType, RegisterWidth, XMMMode, Z80Timing, Z80TimingInfo, ISA,
+use std::{
+    collections::HashMap,
+    env::args,
+    fs,
+    io::Write as _,
+    iter::Peekable,
+    path::PathBuf,
+    str::{FromStr, Lines},
 };
-use crate::InstructionAlias;
 
 use anyhow::{anyhow, Result};
 use htmlentity::entity::ICodedDataTrait;
@@ -25,6 +19,15 @@ use regex::Regex;
 use reqwest;
 use serde::Deserialize;
 use url_escape::encode_www_form_urlencoded;
+
+use crate::{
+    types::{
+        Arch, Assembler, Directive, Instruction, InstructionForm, MMXMode, NameToDirectiveMap,
+        NameToInstructionMap, NameToRegisterMap, Operand, OperandType, Register, RegisterBitInfo,
+        RegisterType, RegisterWidth, XMMMode, Z80Timing, Z80TimingInfo, ISA,
+    },
+    ustr, AvrStatusRegister, AvrTiming, InstructionAlias,
+};
 
 /// Parse all of the register information witin the documentation file
 ///

--- a/asm-lsp/parser.rs
+++ b/asm-lsp/parser.rs
@@ -704,7 +704,7 @@ pub fn populate_6502_instructions(html_conts: &str) -> Result<Vec<Instruction>> 
             match c {
                 '<' => {
                     if prev_idx != 0 {
-                        let bytes: Vec<u8> = synopsis_line[prev_idx..i].as_bytes().to_vec();
+                        let bytes: Vec<u8> = synopsis_line.as_bytes()[prev_idx..i].to_vec();
                         let decoded = htmlentity::entity::decode(&bytes).to_string().unwrap();
                         synopsis += &decoded;
                     }
@@ -2062,6 +2062,7 @@ pub fn populate_ca65_directives(html_conts: &str) -> Result<Vec<Directive>> {
             for (i, c) in description_line.chars().enumerate() {
                 match c {
                     '<' => {
+                        #[allow(clippy::sliced_string_as_bytes)]
                         let bytes: Vec<u8> = description_line[prev_idx..i].as_bytes().to_vec();
                         let decoded = htmlentity::entity::decode(&bytes).to_string().unwrap();
                         description += &decoded;
@@ -2073,10 +2074,9 @@ pub fn populate_ca65_directives(html_conts: &str) -> Result<Vec<Directive>> {
             let line_len = description_line.len();
             // Not all lines end with a closing tag...
             if prev_idx < line_len - 1 {
-                let bytes: Vec<u8> = description_line[prev_idx..description_line.len()]
-                    .as_bytes()
-                    .to_vec();
-                let decoded = htmlentity::entity::decode(&bytes).to_string().unwrap();
+                #[allow(clippy::sliced_string_as_bytes)]
+                let bytes = description_line[prev_idx..description_line.len()].as_bytes();
+                let decoded = htmlentity::entity::decode(bytes).to_string().unwrap();
                 description += &decoded;
             }
             if description.len() != len_before {

--- a/asm-lsp/test.rs
+++ b/asm-lsp/test.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use core::panic;
     use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
     use anyhow::Result;

--- a/asm-lsp/types.rs
+++ b/asm-lsp/types.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    fmt::Display,
+    fmt::{Display, Write as _},
     path::PathBuf,
     str::FromStr,
 };
@@ -182,33 +182,33 @@ impl std::fmt::Display for InstructionForm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = String::new();
         if let Some(val) = &self.gas_name {
-            s += &format!("*GAS*: {val} | ");
+            write!(s, "*GAS*: {val} | ")?;
         }
         if let Some(val) = &self.go_name {
-            s += &format!("*GO*: {val} | ");
+            write!(s, "*GO*: {val} | ")?;
         }
         if let Some(val) = &self.z80_form {
-            s += &format!("*Z80*: {val} | ");
+            write!(s, "*Z80*: {val} | ")?;
         }
         if let Some(val) = &self.avr_mneumonic {
             let version_str = self
                 .avr_version
                 .as_ref()
                 .map_or_else(String::new, |version| format!(" ({version})"));
-            s += &format!("*AVR*: {val}{version_str} | ",);
+            write!(s, "*AVR*: {val}{version_str} | ")?;
         }
 
         if let Some(val) = &self.mmx_mode {
-            s += &(format!("*MMX*: {} | ", val.as_ref()));
+            write!(s, "*MMX*: {} | ", val.as_ref())?;
         }
         if let Some(val) = &self.xmm_mode {
-            s += &(format!("*XMM*: {} | ", val.as_ref()));
+            write!(s, "*XMM*: {} | ", val.as_ref())?;
         }
         if let Some(val) = &self.z80_opcode {
             if val.contains(',') {
-                s += &format!("*Opcodes*: {val} | ");
+                write!(s, "*Opcodes*: {val} | ")?;
             } else {
-                s += &format!("*Opcode*: {val} | ");
+                write!(s, "*Opcode*: {val} | ")?;
             }
         }
 
@@ -218,7 +218,7 @@ impl std::fmt::Display for InstructionForm {
 
         // ISA
         if let Some(val) = &self.isa {
-            s += &format!("*ISA*: {} | ", val.as_ref());
+            write!(s, "*ISA*: {} | ", val.as_ref())?;
         }
 
         if !s.is_empty() {
@@ -234,13 +234,13 @@ impl std::fmt::Display for InstructionForm {
                 .map(|op| {
                     let mut s = format!("  + {:<8}", format!("[{}]", op.type_.as_ref()));
                     if let Some(input) = op.input {
-                        s += &format!(" input = {input:<5} ");
+                        write!(s, " input = {input:<5} ").unwrap();
                     }
                     if let Some(output) = op.output {
-                        s += &format!(" output = {output:<5}");
+                        write!(s, " output = {output:<5}").unwrap();
                     }
                     if let Some(extended_size) = op.extended_size {
-                        s += &format!(" extended-size = {extended_size}");
+                        write!(s, " extended-size = {extended_size}").unwrap();
                     }
 
                     s.trim_end().to_owned()
@@ -252,21 +252,21 @@ impl std::fmt::Display for InstructionForm {
         s += &operands_str;
 
         if let Some(ref timing) = self.z80_timing {
-            s += &format!("\n  + {timing}");
+            write!(s, "\n  + {timing}")?;
         }
 
         if let Some(summary) = &self.avr_summary {
-            s += &format!("\n\n{summary}");
+            write!(s, "\n\n{summary}")?;
         }
         if let Some(sreg) = &self.avr_status_register {
-            s += &format!("\n\n{sreg}");
+            write!(s, "\n\n{sreg}")?;
         }
         if let Some(ref timing) = self.avr_timing {
-            s += &format!("\n\n{timing}\n");
+            writeln!(s, "\n\n{timing}")?;
         }
 
         for url in &self.urls {
-            s += &format!("\n  + More info: {url}\n");
+            writeln!(s, "\n  + More info: {url}")?;
         }
 
         write!(f, "{s}")?;
@@ -287,11 +287,11 @@ impl std::fmt::Display for InstructionAlias {
         let mut s = self.title.clone();
 
         if !self.summary.is_empty() {
-            s += &format!("\n {}", self.summary);
+            write!(s, "\n {}", self.summary)?;
         }
 
         for template in &self.asm_templates {
-            s += &format!("\n + `{template}`");
+            write!(s, "\n + `{template}`")?;
         }
 
         write!(f, "{s}")?;
@@ -531,7 +531,7 @@ impl std::fmt::Display for Directive {
         // signature(s)
         let mut sigs = String::new();
         for sig in &self.signatures {
-            sigs += &format!("- {sig}\n");
+            writeln!(sigs, "- {sig}")?;
         }
         v.push(&sigs);
 
@@ -1066,10 +1066,10 @@ impl std::fmt::Display for RegisterBitInfo {
             format!("{:2}: {} - {}", self.bit, self.label, self.description)
         };
         if !self.pae.is_empty() {
-            s += &format!(", PAE: {}", self.pae);
+            write!(s, ", PAE: {}", self.pae)?;
         }
         if !self.long_mode.is_empty() {
-            s += &format!(", Long Mode: {}", self.long_mode);
+            write!(s, " , Long Mode: {}", self.long_mode)?;
         }
 
         write!(f, "{s}")?;
@@ -1277,6 +1277,7 @@ impl Default for Config {
 }
 
 impl Config {
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn get_compiler(&self) -> Option<&str> {
         match self.opts {

--- a/asm_docs_parsing/src/main.rs
+++ b/asm_docs_parsing/src/main.rs
@@ -1,18 +1,18 @@
 use std::path::PathBuf;
 
-use ::asm_lsp::parser::{
-    populate_6502_instructions, populate_arm_instructions, populate_ca65_directives,
-    populate_gas_directives, populate_instructions, populate_masm_nasm_directives,
-    populate_registers, populate_riscv_instructions, populate_riscv_registers,
-};
-use asm_lsp::{
-    parser::{populate_avr_directives, populate_avr_instructions, populate_power_isa_instructions},
-    Arch, Assembler, Directive, Instruction, Register,
-};
-
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
+
+use asm_lsp::{
+    parser::{
+        populate_6502_instructions, populate_arm_instructions, populate_avr_directives,
+        populate_avr_instructions, populate_ca65_directives, populate_gas_directives,
+        populate_instructions, populate_masm_nasm_directives, populate_power_isa_instructions,
+        populate_registers, populate_riscv_instructions, populate_riscv_registers,
+    },
+    Arch, Assembler, Directive, Instruction, Register,
+};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, clap::ValueEnum)]
 enum DocType {


### PR DESCRIPTION
- Fixes a bug I found in the config builder while debugging another issue
- Addresses some new clippy lints
- Bumps some dependencies
    - Notably absent are the upgrades to bincode and tree-sitter. These will require a few non-trivial changes.