### PR TITLE
add support for ca65 error messages

### DIFF
--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -736,7 +736,7 @@ fn get_diagnostics(diagnostics: &mut Vec<Diagnostic>, tool_output: &str) {
             ));
         }
 
-        // the  ca65 has a light different format
+        // ca65 has a slightly different format
         // file(<line>): <error message here>
         if let Some(caps) = ALT_DIAG_REG_LINE_ONLY.captures(line) {
             if caps.len() < 3 {

--- a/asm-lsp/lsp.rs
+++ b/asm-lsp/lsp.rs
@@ -674,7 +674,6 @@ fn get_diagnostics(diagnostics: &mut Vec<Diagnostic>, tool_output: &str) {
         LazyLock::new(|| Regex::new(r"^.*:(\d+):(\d+):\s+(.*)$").unwrap());
     static DIAG_REG_LINE_ONLY: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^.*:(\d+):\s+(.*)$").unwrap());
-
     static ALT_DIAG_REG_LINE_ONLY: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^.*\((\d+)\):\s+(.*)$").unwrap());
 


### PR DESCRIPTION
I added support for the error format of the ca65 assembler.

i also have seen the comment on line 678, so i tried to avoid making more Regex shenanigan :see_no_evil: 