### PR TITLE
fix(lsp): send error response to request when no data is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ tweak your code for optimisation.
 
 [![MSRV](https://img.shields.io/badge/MSRV-1.82.0-blue)](https://www.rust-lang.org/)
 
-**Note**: The minimum supported Rust version (MSRV) is **1.82.0**, but this may change on the `master` branch.
+**Note**: The minimum supported Rust version (MSRV) is **1.88.0**, but this may change on the `master` branch.
 ...
 
 ### Using cargo

--- a/asm-lsp/bin/main.rs
+++ b/asm-lsp/bin/main.rs
@@ -2,7 +2,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use asm_lsp::config_builder::{GenerateArgs, GenerateOpts, gen_config};
-use asm_lsp::types::LspClient;
 use asm_lsp::{Arch, Assembler, run_info};
 
 use asm_lsp::handle::{handle_notification, handle_request};
@@ -162,7 +161,7 @@ pub fn run_lsp() -> Result<()> {
 
     let params: InitializeParams = serde_json::from_value(initialization_params).unwrap();
     info!("Client initialization params: {:?}", params);
-    let mut config = match get_root_config(&params) {
+    let config = match get_root_config(&params) {
         Ok(cfg) => cfg,
         Err(e) => {
             let msg = format!("{e}. Please make corrections and restart asm-lsp.");
@@ -178,12 +177,6 @@ pub fn run_lsp() -> Result<()> {
         send_notification(msg, MessageType::WARNING, &connection)?;
     }
     info!("Server Configuration: {:?}", config);
-    if let Some(ref client_info) = params.client_info {
-        if client_info.name.eq("helix") {
-            info!("Helix LSP client detected");
-            config.set_client(LspClient::Helix);
-        }
-    }
 
     let mut store = ServerStore::default();
     // Populate names to `Instruction`/`Register`/`Directive` maps

--- a/asm-lsp/config_builder.rs
+++ b/asm-lsp/config_builder.rs
@@ -483,7 +483,6 @@ fn prompt_config() -> Config {
         instruction_set,
         assembler,
         opts,
-        client: None,
     }
 }
 

--- a/asm-lsp/handle.rs
+++ b/asm-lsp/handle.rs
@@ -325,24 +325,23 @@ pub fn handle_completion_request(
     completion_items: &CompletionItems,
 ) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
-    if let Some(doc) = doc_store.text_store.get_document(uri) {
-        if let Some(ref mut tree_entry) = doc_store.tree_store.get_mut(uri) {
-            if let Some(comp_resp) = get_comp_resp(
-                doc.get_content(None),
-                tree_entry,
-                params,
-                config,
-                completion_items,
-            ) {
-                let result = serde_json::to_value(comp_resp).unwrap();
-                let result = Response {
-                    id,
-                    result: Some(result),
-                    error: None,
-                };
-                return Ok(connection.sender.send(Message::Response(result))?);
-            }
-        }
+    if let Some(doc) = doc_store.text_store.get_document(uri)
+        && let Some(ref mut tree_entry) = doc_store.tree_store.get_mut(uri)
+        && let Some(comp_resp) = get_comp_resp(
+            doc.get_content(None),
+            tree_entry,
+            params,
+            config,
+            completion_items,
+        )
+    {
+        let result = serde_json::to_value(comp_resp).unwrap();
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
+        return Ok(connection.sender.send(Message::Response(result))?);
     }
 
     send_empty_resp(connection, id)
@@ -364,19 +363,18 @@ pub fn handle_goto_def_request(
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document_position_params.text_document.uri;
-    if let Some(doc) = doc_store.text_store.get_document(uri) {
-        if let Some(tree_entry) = doc_store.tree_store.get_mut(uri) {
-            if let Some(def_resp) = get_goto_def_resp(doc, tree_entry, params) {
-                let result = serde_json::to_value(def_resp).unwrap();
-                let result = Response {
-                    id,
-                    result: Some(result),
-                    error: None,
-                };
+    if let Some(doc) = doc_store.text_store.get_document(uri)
+        && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
+        && let Some(def_resp) = get_goto_def_resp(doc, tree_entry, params)
+    {
+        let result = serde_json::to_value(def_resp).unwrap();
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
 
-                return Ok(connection.sender.send(Message::Response(result))?);
-            }
-        }
+        return Ok(connection.sender.send(Message::Response(result))?);
     }
 
     send_empty_resp(connection, id)
@@ -398,19 +396,18 @@ pub fn handle_document_symbols_request(
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document.uri;
-    if let Some(doc) = doc_store.text_store.get_document(uri) {
-        if let Some(tree_entry) = doc_store.tree_store.get_mut(uri) {
-            if let Some(symbols) = get_document_symbols(doc.get_content(None), tree_entry, params) {
-                let resp = DocumentSymbolResponse::Nested(symbols);
-                let result = serde_json::to_value(resp).unwrap();
-                let result = Response {
-                    id,
-                    result: Some(result),
-                    error: None,
-                };
-                return Ok(connection.sender.send(Message::Response(result))?);
-            }
-        }
+    if let Some(doc) = doc_store.text_store.get_document(uri)
+        && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
+        && let Some(symbols) = get_document_symbols(doc.get_content(None), tree_entry, params)
+    {
+        let resp = DocumentSymbolResponse::Nested(symbols);
+        let result = serde_json::to_value(resp).unwrap();
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
+        return Ok(connection.sender.send(Message::Response(result))?);
     }
 
     send_empty_resp(connection, id)
@@ -434,27 +431,23 @@ pub fn handle_signature_help_request(
     names_to_instructions: &NameToInstructionMap,
 ) -> Result<()> {
     let uri = &params.text_document_position_params.text_document.uri;
-    if let Some(doc) = doc_store.text_store.get_document(uri) {
-        if let Some(tree_entry) = doc_store.tree_store.get_mut(uri) {
-            let sig_resp = get_sig_help_resp(
-                doc.get_content(None),
-                params,
-                config,
-                tree_entry,
-                names_to_instructions,
-            );
-
-            if let Some(sig) = sig_resp {
-                let result = serde_json::to_value(sig).unwrap();
-                let result = Response {
-                    id,
-                    result: Some(result),
-                    error: None,
-                };
-
-                return Ok(connection.sender.send(Message::Response(result))?);
-            }
-        }
+    if let Some(doc) = doc_store.text_store.get_document(uri)
+        && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
+        && let Some(sig_resp) = get_sig_help_resp(
+            doc.get_content(None),
+            params,
+            config,
+            tree_entry,
+            names_to_instructions,
+        )
+    {
+        let result = serde_json::to_value(sig_resp).unwrap();
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
+        return Ok(connection.sender.send(Message::Response(result))?);
     }
 
     send_empty_resp(connection, id)
@@ -476,20 +469,20 @@ pub fn handle_references_request(
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
-    if let Some(doc) = doc_store.text_store.get_document(uri) {
-        if let Some(tree_entry) = doc_store.tree_store.get_mut(uri) {
-            let ref_resp = get_ref_resp(params, doc, tree_entry);
             if !ref_resp.is_empty() {
-                let result = serde_json::to_value(&ref_resp).unwrap();
-
-                let result = Response {
-                    id,
-                    result: Some(result),
-                    error: None,
-                };
-                return Ok(connection.sender.send(Message::Response(result))?);
             }
-        }
+    if let Some(doc) = doc_store.text_store.get_document(uri)
+        && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
+    {
+        let ref_resp = get_ref_resp(params, doc, tree_entry);
+        let result = serde_json::to_value(&ref_resp).unwrap();
+
+        let result = Response {
+            id,
+            result: Some(result),
+            error: None,
+        };
+        return Ok(connection.sender.send(Message::Response(result))?);
     }
 
     send_empty_resp(connection, id)
@@ -642,18 +635,15 @@ pub fn handle_did_change_text_document_notification(
         .listen(DidChangeTextDocument::METHOD, &raw_params);
 
     let uri = &params.text_document.uri;
-    if let Some(ref mut doc) = doc_store.text_store.get_document(uri) {
-        if let Some(tree_entry) = doc_store.tree_store.get_mut(uri) {
-            if let Some(ref mut curr_tree) = tree_entry.tree {
-                for change in &params.content_changes {
-                    match text_doc_change_to_ts_edit(change, doc) {
-                        Ok(edit) => {
-                            curr_tree.edit(&edit);
-                        }
-                        Err(e) => {
-                            return Err(anyhow!("Bad edit info, failed to edit tree - Error: {e}"));
-                        }
-                    }
+    if let Some(ref mut doc) = doc_store.text_store.get_document(uri)
+        && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
+        && let Some(ref mut curr_tree) = tree_entry.tree
+    {
+        for change in &params.content_changes {
+            match text_doc_change_to_ts_edit(change, doc) {
+                Ok(edit) => curr_tree.edit(&edit),
+                Err(e) => {
+                    return Err(anyhow!("Bad edit info, failed to edit tree - Error: {e}"));
                 }
             }
         }

--- a/asm-lsp/handle.rs
+++ b/asm-lsp/handle.rs
@@ -469,8 +469,6 @@ pub fn handle_references_request(
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
-            if !ref_resp.is_empty() {
-            }
     if let Some(doc) = doc_store.text_store.get_document(uri)
         && let Some(tree_entry) = doc_store.tree_store.get_mut(uri)
     {

--- a/asm-lsp/handle.rs
+++ b/asm-lsp/handle.rs
@@ -81,13 +81,7 @@ pub fn handle_request(
         GotoDefinition::METHOD => {
             let (id, params) =
                 cast_req::<GotoDefinition>(req).expect("Failed to cast completion request");
-            handle_goto_def_request(
-                connection,
-                id,
-                &params,
-                config.get_config(&params.text_document_position_params.text_document.uri),
-                doc_store,
-            )?;
+            handle_goto_def_request(connection, id, &params, doc_store)?;
             info!(
                 "{} request serviced in {}ms",
                 GotoDefinition::METHOD,
@@ -97,13 +91,7 @@ pub fn handle_request(
         DocumentSymbolRequest::METHOD => {
             let (id, params) =
                 cast_req::<DocumentSymbolRequest>(req).expect("Failed to cast completion request");
-            handle_document_symbols_request(
-                connection,
-                id,
-                &params,
-                config.get_config(&params.text_document.uri),
-                doc_store,
-            )?;
+            handle_document_symbols_request(connection, id, &params, doc_store)?;
             info!(
                 "{} request serviced in {}ms",
                 DocumentSymbolRequest::METHOD,
@@ -130,13 +118,7 @@ pub fn handle_request(
         References::METHOD => {
             let (id, params) =
                 cast_req::<References>(req).expect("Failed to cast completion request");
-            handle_references_request(
-                connection,
-                id,
-                &params,
-                config.get_config(&params.text_document_position.text_document.uri),
-                doc_store,
-            )?;
+            handle_references_request(connection, id, &params, doc_store)?;
             info!(
                 "{} request serviced in {}ms",
                 References::METHOD,
@@ -305,7 +287,7 @@ pub fn handle_hover_request(
     {
         get_word_from_pos_params(doc, &params.text_document_position_params)
     } else {
-        return send_empty_resp(connection, id, config);
+        return send_empty_resp(connection, id);
     };
 
     // needed to appease the borrow checker, since `word` is a reference to owned
@@ -322,7 +304,7 @@ pub fn handle_hover_request(
         return Ok(connection.sender.send(Message::Response(result))?);
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Handles completion requests
@@ -363,7 +345,7 @@ pub fn handle_completion_request(
         }
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Handles go to definition requests
@@ -379,7 +361,6 @@ pub fn handle_goto_def_request(
     connection: &Connection,
     id: RequestId,
     params: &GotoDefinitionParams,
-    config: &Config,
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document_position_params.text_document.uri;
@@ -398,7 +379,7 @@ pub fn handle_goto_def_request(
         }
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Handles document symbols requests
@@ -414,7 +395,6 @@ pub fn handle_document_symbols_request(
     connection: &Connection,
     id: RequestId,
     params: &DocumentSymbolParams,
-    config: &Config,
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document.uri;
@@ -433,7 +413,7 @@ pub fn handle_document_symbols_request(
         }
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Handles signature help requests
@@ -477,7 +457,7 @@ pub fn handle_signature_help_request(
         }
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Handles reference requests
@@ -493,7 +473,6 @@ pub fn handle_references_request(
     connection: &Connection,
     id: RequestId,
     params: &ReferenceParams,
-    config: &Config,
     doc_store: &mut DocumentStore,
 ) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
@@ -513,7 +492,7 @@ pub fn handle_references_request(
         }
     }
 
-    send_empty_resp(connection, id, config)
+    send_empty_resp(connection, id)
 }
 
 /// Produces diagnostics and sends a `PublishDiagnostics` notification to the client

--- a/asm-lsp/test.rs
+++ b/asm-lsp/test.rs
@@ -37,7 +37,6 @@ mod tests {
                 diagnostics: None,
                 default_diagnostics: None,
             }),
-            client: None,
         }
     }
 
@@ -47,7 +46,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::Mips,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -57,7 +55,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::Avr,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -67,7 +64,6 @@ mod tests {
             assembler: Assembler::Avr,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -77,7 +73,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::PowerISA,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -87,7 +82,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::MOS6502,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -97,7 +91,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::Z80,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -107,7 +100,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::ARM,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -117,7 +109,6 @@ mod tests {
             assembler: Assembler::None,
             instruction_set: Arch::RISCV,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -132,7 +123,6 @@ mod tests {
             assembler: Assembler::Gas,
             instruction_set: Arch::X86_AND_X86_64,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -142,7 +132,6 @@ mod tests {
             assembler: Assembler::Gas,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -152,7 +141,6 @@ mod tests {
             assembler: Assembler::Masm,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -162,7 +150,6 @@ mod tests {
             assembler: Assembler::Nasm,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -172,7 +159,6 @@ mod tests {
             assembler: Assembler::Ca65,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -182,7 +168,6 @@ mod tests {
             assembler: Assembler::Fasm,
             instruction_set: Arch::None,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 
@@ -194,7 +179,6 @@ mod tests {
             // Mars's pseudo instructions
             instruction_set: Arch::Mips,
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 

--- a/asm-lsp/types.rs
+++ b/asm-lsp/types.rs
@@ -1352,8 +1352,6 @@ pub struct Config {
     pub assembler: Assembler,
     pub instruction_set: Arch,
     pub opts: Option<ConfigOptions>,
-    #[serde(skip)]
-    pub client: Option<LspClient>,
 }
 
 impl Default for Config {
@@ -1363,7 +1361,6 @@ impl Default for Config {
             assembler: Assembler::default(),
             instruction_set: Arch::default(),
             opts: Some(ConfigOptions::default()),
-            client: None,
         }
     }
 }
@@ -1432,11 +1429,6 @@ impl Default for ConfigOptions {
             default_diagnostics: Some(true),
         }
     }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LspClient {
-    Helix,
 }
 
 // Instruction Set Architecture

--- a/asm-lsp/types.rs
+++ b/asm-lsp/types.rs
@@ -1296,25 +1296,12 @@ impl RootConfig {
         assembler_set.into_iter().collect()
     }
 
-    /// Sets the `client` field of the default config and all project configs
-    pub fn set_client(&mut self, client: LspClient) {
-        if let Some(ref mut root) = self.default_config {
-            root.client = Some(client);
-        }
-
-        if let Some(ref mut projects) = self.projects {
-            for project in projects {
-                project.config.client = Some(client);
-            }
-        }
-    }
-
     #[must_use]
     pub fn is_isa_enabled(&self, isa: Arch) -> bool {
-        if let Some(ref root) = self.default_config {
-            if root.is_isa_enabled(isa) {
-                return true;
-            }
+        if let Some(ref root) = self.default_config
+            && root.is_isa_enabled(isa)
+        {
+            return true;
         }
 
         if let Some(ref projects) = self.projects {
@@ -1330,10 +1317,10 @@ impl RootConfig {
 
     #[must_use]
     pub fn is_assembler_enabled(&self, assembler: Assembler) -> bool {
-        if let Some(ref root) = self.default_config {
-            if root.is_assembler_enabled(assembler) {
-                return true;
-            }
+        if let Some(ref root) = self.default_config
+            && root.is_assembler_enabled(assembler)
+        {
+            return true;
         }
 
         if let Some(ref projects) = self.projects {


### PR DESCRIPTION
Sending a response with both `error` and `result` set to `None` does not
conform to the LSP spec, and results in an error being displayed by
Neovim's client.

With this change, we no longer have to special-case Helix's client.

Also, this PR also makes use of the new nested if let chains.

- Closes #256 