### PR TITLE
Support for adding asm-lsp binary within VSIX

### DIFF
--- a/asm-lsp/bin/main.rs
+++ b/asm-lsp/bin/main.rs
@@ -234,7 +234,7 @@ fn main_loop(connection: &Connection, config: &RootConfig, store: &ServerStore) 
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req)? {
-                    info!("Recieved shutdown request");
+                    info!("Received shutdown request");
                     return Ok(());
                 }
                 handle_request(req, connection, config, &mut doc_store, store)?;

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -17,3 +17,11 @@ npm install
 
 In VSCode, go to the `Run & Debug` sidebar (Ctrl + Shft + D) and click the `Run Extension (Debug Build)`
 button. This will open a new VSCode instance with the lsp server installed.
+
+### Adding the binary inside VSIX
+
+Copy the asm-lsp binary into `editors/code/bin/{platform}-{arch}/`.
+
+```console
+npm run package
+```

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -15,5 +15,5 @@ npm install
 
 ### Debugging
 
-In VSCoode, go to the `Run & Debug` sidebar (Ctrl + Shft + D) and click the `Run Extension (Debug Build)`
+In VSCode, go to the `Run & Debug` sidebar (Ctrl + Shft + D) and click the `Run Extension (Debug Build)`
 button. This will open a new VSCode instance with the lsp server installed.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -45,6 +45,7 @@
             }
         ]
     },
+    "publisher": "asm-lsp",
     "devDependencies": {
         "@types/node": "^18.14.6",
         "@types/vscode": "^1.75.1",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -1,3 +1,4 @@
+import path = require("path");
 import * as vscode from "vscode";
 import {
   Executable,
@@ -40,8 +41,15 @@ const middleware: Middleware = {
 };
 let client: LanguageClient;
 
+function serverExecutable() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const exe = platform === 'win32' ? 'asm-lsp.exe' : 'asm-lsp';
+  return path.join(__dirname, '..', 'bin', `${platform}-${arch}`, exe);
+}
+
 export function activate(_: vscode.ExtensionContext) {
-  const serverPath = process.env.SERVER_PATH;
+  const serverPath = process.env.SERVER_PATH || serverExecutable();
 
   if (!serverPath) {
     vscode.window.showErrorMessage(


### PR DESCRIPTION
Added support for including the `asm-lsp` binary within the VSIX.

Also fixed some small typo and added a placeholder for publisher which is required when packaging.
https://code.visualstudio.com/api/references/extension-manifest